### PR TITLE
Fix Aync Typo

### DIFF
--- a/Source/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
+++ b/Source/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
@@ -219,7 +219,7 @@ namespace BLE.Client.ViewModels
             {
                 _userDialogs.ShowLoading("Connecting ...");
 
-                await Adapter.ConnectToDeviceAync(device.Device);
+                await Adapter.ConnectToDeviceAsync(device.Device);
 
                 _userDialogs.InfoToast($"Connected to {device.Device.Name}.");
 
@@ -283,7 +283,7 @@ namespace BLE.Client.ViewModels
                 using (item.Device)
                 {
                     _userDialogs.ShowLoading($"Connecting to {item.Name} ...");
-                    await Adapter.ConnectToDeviceAync(item.Device);
+                    await Adapter.ConnectToDeviceAsync(item.Device);
                     item.Update();
                     _userDialogs.InfoToast($"Connected {item.Device.Name}");
 

--- a/Source/Plugin.BLE.Abstractions/AdapterBase.cs
+++ b/Source/Plugin.BLE.Abstractions/AdapterBase.cs
@@ -86,7 +86,7 @@ namespace Plugin.BLE.Abstractions
             return Task.FromResult(0);
         }
 
-        public Task ConnectToDeviceAync(IDevice device, bool autoconnect = false, CancellationToken cancellationToken = default(CancellationToken))
+        public Task ConnectToDeviceAsync(IDevice device, bool autoconnect = false, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (device.State == DeviceState.Connected)
                 return Task.FromResult(true);
@@ -94,14 +94,14 @@ namespace Plugin.BLE.Abstractions
             return TaskBuilder.FromEvent<bool, EventHandler<DeviceEventArgs>, EventHandler<DeviceErrorEventArgs>>(
                 execute: () =>
                 {
-                    ConnectToDeviceNativeAync(device, autoconnect, cancellationToken);
+                    ConnectToDeviceNativeAsync(device, autoconnect, cancellationToken);
                 },
 
                 getCompleteHandler: complete => (sender, args) =>
                 {
                     if (args.Device.Id == device.Id)
                     {
-                        Trace.Message("ConnectToDeviceAync Connected: {0} {1}", args.Device.Id, args.Device.Name);
+                        Trace.Message("ConnectToDeviceAsync Connected: {0} {1}", args.Device.Id, args.Device.Name);
                         complete(true);
                     }
                 },
@@ -222,7 +222,7 @@ namespace Plugin.BLE.Abstractions
 
         protected abstract Task StartScanningForDevicesNativeAsync(Guid[] serviceUuids, CancellationToken scanCancellationToken);
         protected abstract void StopScanNative();
-        protected abstract Task ConnectToDeviceNativeAync(IDevice device, bool autoconnect, CancellationToken cancellationToken);
+        protected abstract Task ConnectToDeviceNativeAsync(IDevice device, bool autoconnect, CancellationToken cancellationToken);
         protected abstract void DisconnectDeviceNative(IDevice device);
     }
 }

--- a/Source/Plugin.BLE.Abstractions/Contracts/IAdapter.cs
+++ b/Source/Plugin.BLE.Abstractions/Contracts/IAdapter.cs
@@ -82,7 +82,7 @@ namespace Plugin.BLE.Abstractions.Contracts
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
         /// <returns>A task that represents the asynchronous read operation. The Task will finish after the device has been connected successfuly.</returns>
         /// <exception cref="DeviceConnectionException">Thrown if the device connection fails.</exception>
-        Task ConnectToDeviceAync(IDevice device, bool autoconnect = false, CancellationToken cancellationToken = default(CancellationToken));
+        Task ConnectToDeviceAsync(IDevice device, bool autoconnect = false, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Disconnects from the <paramref name="device"/>.

--- a/Source/Plugin.BLE.Abstractions/Extensions/AdapterExtenstion.cs
+++ b/Source/Plugin.BLE.Abstractions/Extensions/AdapterExtenstion.cs
@@ -91,9 +91,9 @@ namespace Plugin.BLE.Abstractions.Extensions
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
         /// <returns>A task that represents the asynchronous read operation. The Task will finish after the device has been connected successfuly.</returns>
         /// <exception cref="DeviceConnectionException">Thrown if the device connection fails.</exception>
-        public static Task ConnectToDeviceAync(this IAdapter adapter, IDevice device, CancellationToken cancellationToken)
+        public static Task ConnectToDeviceAsync(this IAdapter adapter, IDevice device, CancellationToken cancellationToken)
         {
-            return adapter.ConnectToDeviceAync(device, cancellationToken: cancellationToken);
+            return adapter.ConnectToDeviceAsync(device, cancellationToken: cancellationToken);
         }
     }
 }

--- a/Source/Plugin.BLE.Abstractions/Utils/FakeAdapter.cs
+++ b/Source/Plugin.BLE.Abstractions/Utils/FakeAdapter.cs
@@ -20,7 +20,7 @@ namespace Plugin.BLE.Abstractions.Utils
             TraceUnavailability();
         }
 
-        protected override Task ConnectToDeviceNativeAync(IDevice device, bool autoconnect, CancellationToken cancellationToken)
+        protected override Task ConnectToDeviceNativeAsync(IDevice device, bool autoconnect, CancellationToken cancellationToken)
         {
             TraceUnavailability();
             return Task.FromResult(0);

--- a/Source/Plugin.BLE.Android/Adapter.cs
+++ b/Source/Plugin.BLE.Android/Adapter.cs
@@ -154,7 +154,7 @@ namespace Plugin.BLE.Android
             }
         }
 
-        protected override Task ConnectToDeviceNativeAync(IDevice device, bool autoconnect, CancellationToken cancellationToken)
+        protected override Task ConnectToDeviceNativeAsync(IDevice device, bool autoconnect, CancellationToken cancellationToken)
         {
             AddToDeviceOperationRegistry(device);
             ((BluetoothDevice)device.NativeDevice).ConnectGatt(Application.Context, autoconnect, _gattCallback);

--- a/Source/Plugin.BLE.iOS/Adapter.cs
+++ b/Source/Plugin.BLE.iOS/Adapter.cs
@@ -154,7 +154,7 @@ namespace Plugin.BLE.iOS
             _centralManager.StopScan();
         }
 
-        protected override Task ConnectToDeviceNativeAync(IDevice device, bool autoconnect, CancellationToken cancellationToken)
+        protected override Task ConnectToDeviceNativeAsync(IDevice device, bool autoconnect, CancellationToken cancellationToken)
         {
             if (autoconnect)
             {


### PR DESCRIPTION
There were a few methods where "Async" was spelled "Aync." It isn't a terribly huge deal, but it became a bit of a hassle to remember which methods were spelled "Async" vs. "Aync" when my team and I were using the library. 