### PR TITLE
Master

### DIFF
--- a/Source/Plugin.BLE.iOS/Adapter.cs
+++ b/Source/Plugin.BLE.iOS/Adapter.cs
@@ -299,7 +299,11 @@ namespace Plugin.BLE.iOS
                 }
 				else if (key == CBAdvertisement.DataTxPowerLevelKey)
 				{
-					var arr = NSData.FromString(advertisementData.ObjectForKey(key).ToString()).ToArray();
+					//iOS stores TxPower as NSNumber. Get int value of number and convert it into a signed Byte
+					//TxPower has a range from -100 to 20 which can fit into a single signed byte (-128 to 127)
+					sbyte byteValue = Convert.ToSByte(((NSNumber)advertisementData.ObjectForKey(key)).Int32Value);
+					//add our signed byte to a new byte array and return it (same parsed value as android returns)
+					byte[] arr = { (byte)byteValue };
 					records.Add(new AdvertisementRecord(AdvertisementRecordType.TxPowerLevel, arr));
 				}
                 else


### PR DESCRIPTION
On further inspection of Android parsing of TxPower; value should be parsed as a single signed byte.  This commit makes the iOS and Android parsing return the identical value for TxPower.