### PR TITLE
Add support for NSString descriptor values

### DIFF
--- a/Source/Plugin.BLE.iOS/Descriptor.cs
+++ b/Source/Plugin.BLE.iOS/Descriptor.cs
@@ -28,6 +28,11 @@ namespace Plugin.BLE.iOS
                     return BitConverter.GetBytes(((NSNumber)_nativeDescriptor.Value).UInt64Value);
                 }
 
+                if (_nativeDescriptor.Value is NSString)
+                {
+                    return System.Text.Encoding.UTF8.GetBytes(((NSString)_nativeDescriptor.Value).ToString());
+                }
+
                 //TODO https://developer.apple.com/reference/corebluetooth/cbuuid/1667288-characteristic_descriptors
                 Trace.Message($"Descriptor: can't convert {_nativeDescriptor.Value?.GetType().Name} with value {_nativeDescriptor.Value?.ToString()} to byte[]");
                 return null;


### PR DESCRIPTION
IDescriptor.ReadAsync() fails (i.e. it returns null) on iOS if the descriptor's value is a string. This commit fixes this by converting the NSString value to an UTF8-encoded byte-array.