### PR TITLE
Added requestMTU feature (issue #128)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 *.userosscache
 *.sln.docstates
 
+# Mac OSX
+.DS_Store
+
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 

--- a/Source/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
+++ b/Source/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
@@ -399,6 +399,10 @@ namespace BLE.Client.ViewModels
                 {
                     _userDialogs.ShowLoading($"Connecting to {item.Name} ...");
                     await Adapter.ConnectToDeviceAsync(item.Device);
+
+                    var resultMTU = await item.Device.RequestMtuAsync(60);
+                    System.Diagnostics.Debug.WriteLine($"Requested MTU. Result is {resultMTU}");
+
                     item.Update();
                     _userDialogs.ShowSuccess($"Connected {item.Device.Name}");
 

--- a/Source/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
+++ b/Source/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
@@ -400,6 +400,7 @@ namespace BLE.Client.ViewModels
                     _userDialogs.ShowLoading($"Connecting to {item.Name} ...");
                     await Adapter.ConnectToDeviceAsync(item.Device);
 
+                    // TODO make this configurable
                     var resultMTU = await item.Device.RequestMtuAsync(60);
                     System.Diagnostics.Debug.WriteLine($"Requested MTU. Result is {resultMTU}");
 

--- a/Source/Plugin.BLE.Abstractions/Contracts/IDevice.cs
+++ b/Source/Plugin.BLE.Abstractions/Contracts/IDevice.cs
@@ -1,4 +1,4 @@
-using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -74,5 +74,17 @@ namespace Plugin.BLE.Abstractions.Contracts
         /// The Task will finish after Rssi has been updated.
         /// </returns>
         Task<bool> UpdateRssiAsync();
+
+		/// <summary>
+		/// Requests a MTU update and fires an "Exchange MTU Request" on the ble stack. Be aware that the resulting MTU value will be negotiated between master and slave using your requested value for the negotiation.
+		/// 
+		/// Important:
+		/// On Android: This function will only work with API level 21 and higher. Other API level will get an default value as function result.
+        /// On iOS: Requesting MTU sizes is not supported by iOS. The function will return the current negotiated MTU between master / slave.
+		/// </summary>
+		/// <returns>
+		/// A task that represents the asynchronous operation. The result contains the negotiated MTU size between master and slave</returns>
+		/// <param name="requestValue">The requested MTU</param>
+		Task<int> RequestMtuAsync(int requestValue);
     }
 }

--- a/Source/Plugin.BLE.Abstractions/Contracts/IDevice.cs
+++ b/Source/Plugin.BLE.Abstractions/Contracts/IDevice.cs
@@ -1,4 +1,4 @@
-﻿﻿using System;
+﻿﻿﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -75,16 +75,16 @@ namespace Plugin.BLE.Abstractions.Contracts
         /// </returns>
         Task<bool> UpdateRssiAsync();
 
-		/// <summary>
-		/// Requests a MTU update and fires an "Exchange MTU Request" on the ble stack. Be aware that the resulting MTU value will be negotiated between master and slave using your requested value for the negotiation.
-		/// 
-		/// Important:
-		/// On Android: This function will only work with API level 21 and higher. Other API level will get an default value as function result.
+        /// <summary>
+        /// Requests a MTU update and fires an "Exchange MTU Request" on the ble stack. Be aware that the resulting MTU value will be negotiated between master and slave using your requested value for the negotiation.
+        /// 
+        /// Important: 
+        /// On Android: This function will only work with API level 21 and higher. Other API level will get an default value as function result.
         /// On iOS: Requesting MTU sizes is not supported by iOS. The function will return the current negotiated MTU between master / slave.
-		/// </summary>
-		/// <returns>
-		/// A task that represents the asynchronous operation. The result contains the negotiated MTU size between master and slave</returns>
-		/// <param name="requestValue">The requested MTU</param>
-		Task<int> RequestMtuAsync(int requestValue);
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous operation. The result contains the negotiated MTU size between master and slave</returns>
+        /// <param name="requestValue">The requested MTU</param>
+        Task<int> RequestMtuAsync(int requestValue);
     }
 }

--- a/Source/Plugin.BLE.Abstractions/DeviceBase.cs
+++ b/Source/Plugin.BLE.Abstractions/DeviceBase.cs
@@ -41,10 +41,10 @@ namespace Plugin.BLE.Abstractions
             return services.FirstOrDefault(x => x.Id == id);
         }
 
-		public async Task<int> RequestMtuAsync(int requestValue)
-		{
-			return await RequestMtuNativeAsync(requestValue);
-		}
+        public async Task<int> RequestMtuAsync(int requestValue)
+        {
+            return await RequestMtuNativeAsync(requestValue);
+        }
 
         public abstract Task<bool> UpdateRssiAsync();
         protected abstract DeviceState GetState();

--- a/Source/Plugin.BLE.Abstractions/DeviceBase.cs
+++ b/Source/Plugin.BLE.Abstractions/DeviceBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -41,10 +41,15 @@ namespace Plugin.BLE.Abstractions
             return services.FirstOrDefault(x => x.Id == id);
         }
 
-        public abstract Task<bool> UpdateRssiAsync();
+		public async Task<int> RequestMtuAsync(int requestValue)
+		{
+			return await RequestMtuNativeAsync(requestValue);
+		}
 
+        public abstract Task<bool> UpdateRssiAsync();
         protected abstract DeviceState GetState();
         protected abstract Task<IEnumerable<IService>> GetServicesNativeAsync();
+        protected abstract Task<int> RequestMtuNativeAsync(int requestValue);
 
         public override string ToString()
         {
@@ -83,6 +88,8 @@ namespace Plugin.BLE.Abstractions
         {
             return Id.GetHashCode();
         }
+
+
 
         #endregion
     }

--- a/Source/Plugin.BLE.Android/CallbackEventArgs/MtuRequestCallbackEventArgs.cs
+++ b/Source/Plugin.BLE.Android/CallbackEventArgs/MtuRequestCallbackEventArgs.cs
@@ -1,13 +1,17 @@
-﻿﻿using System; 
+﻿﻿using System;
+using Plugin.BLE.Abstractions.Contracts;
 
 namespace Plugin.BLE.Android.CallbackEventArgs 
 { 
     public class MtuRequestCallbackEventArgs : EventArgs 
     { 
+        public IDevice Device { get; }
         public Exception Error { get; } 
         public int Mtu { get; } 
-        public MtuRequestCallbackEventArgs(Exception error, int mtu) 
+
+        public MtuRequestCallbackEventArgs(IDevice device, Exception error, int mtu) 
         { 
+            Device = device;
             Error = error; 
             Mtu = mtu; 
         } 

--- a/Source/Plugin.BLE.Android/CallbackEventArgs/MtuRequestCallbackEventArgs.cs
+++ b/Source/Plugin.BLE.Android/CallbackEventArgs/MtuRequestCallbackEventArgs.cs
@@ -1,16 +1,15 @@
-﻿using System;
+﻿﻿using System; 
 
-namespace Plugin.BLE.Android.CallbackEventArgs
-{
-	public class MtuRequestCallbackEventArgs : EventArgs
-	{
-		public Exception Error { get; }
-		public int Mtu { get; }
-
-		public MtuRequestCallbackEventArgs(Exception error, int mtu)
-		{
-			Error = error;
-			Mtu = mtu;
-		}
-	}
+namespace Plugin.BLE.Android.CallbackEventArgs 
+{ 
+    public class MtuRequestCallbackEventArgs : EventArgs 
+    { 
+        public Exception Error { get; } 
+        public int Mtu { get; } 
+        public MtuRequestCallbackEventArgs(Exception error, int mtu) 
+        { 
+            Error = error; 
+            Mtu = mtu; 
+        } 
+    }
 }

--- a/Source/Plugin.BLE.Android/CallbackEventArgs/MtuRequestCallbackEventArgs.cs
+++ b/Source/Plugin.BLE.Android/CallbackEventArgs/MtuRequestCallbackEventArgs.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Plugin.BLE.Android.CallbackEventArgs
+{
+	public class MtuRequestCallbackEventArgs : EventArgs
+	{
+		public Exception Error { get; }
+		public int Mtu { get; }
+
+		public MtuRequestCallbackEventArgs(Exception error, int mtu)
+		{
+			Error = error;
+			Mtu = mtu;
+		}
+	}
+}

--- a/Source/Plugin.BLE.Android/Device.cs
+++ b/Source/Plugin.BLE.Android/Device.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/Source/Plugin.BLE.Android/Device.cs
+++ b/Source/Plugin.BLE.Android/Device.cs
@@ -227,6 +227,13 @@ namespace Plugin.BLE.Android
 
         protected override async Task<int> RequestMtuNativeAsync(int requestValue)
         {
+            if (_gatt == null || _gattCallback == null)
+            {
+                Trace.Message("You can't request a MTU for disconnected devices. Device is {0}", State);
+                return -1;
+            }
+
+
             if (Build.VERSION.SdkInt < BuildVersionCodes.Lollipop)
             {
                 Trace.Message($"Request MTU not supported in this Android API level");

--- a/Source/Plugin.BLE.Android/GattCallback.cs
+++ b/Source/Plugin.BLE.Android/GattCallback.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Android.Bluetooth;
 using Plugin.BLE.Abstractions;
 using Plugin.BLE.Abstractions.Contracts;
@@ -16,6 +16,7 @@ namespace Plugin.BLE.Android
         event EventHandler<DescriptorCallbackEventArgs> DescriptorValueWritten;
         event EventHandler<DescriptorCallbackEventArgs> DescriptorValueRead;
         event EventHandler<RssiReadCallbackEventArgs> RemoteRssiRead;
+        event EventHandler<MtuRequestCallbackEventArgs> MtuRequested;
     }
 
     public class GattCallback : BluetoothGattCallback, IGattCallback
@@ -27,6 +28,7 @@ namespace Plugin.BLE.Android
         public event EventHandler<RssiReadCallbackEventArgs> RemoteRssiRead;
         public event EventHandler<DescriptorCallbackEventArgs> DescriptorValueWritten;
         public event EventHandler<DescriptorCallbackEventArgs> DescriptorValueRead;
+        public event EventHandler<MtuRequestCallbackEventArgs> MtuRequested;
 
         public GattCallback(Adapter adapter)
         {
@@ -172,6 +174,14 @@ namespace Plugin.BLE.Android
             base.OnReliableWriteCompleted(gatt, status);
 
             Trace.Message("OnReliableWriteCompleted: {0}", status);
+        }
+
+        public override void OnMtuChanged(BluetoothGatt gatt, int mtu, GattStatus status)
+        {
+            base.OnMtuChanged(gatt, mtu, status);
+
+            Trace.Message("OnMtuChanged to value: {0}", mtu);
+            MtuRequested?.Invoke(this, new MtuRequestCallbackEventArgs(GetExceptionFromGattStatus(status), mtu));
         }
 
         public override void OnReadRemoteRssi(BluetoothGatt gatt, int rssi, GattStatus status)

--- a/Source/Plugin.BLE.Android/GattCallback.cs
+++ b/Source/Plugin.BLE.Android/GattCallback.cs
@@ -181,7 +181,14 @@ namespace Plugin.BLE.Android
             base.OnMtuChanged(gatt, mtu, status);
 
             Trace.Message("OnMtuChanged to value: {0}", mtu);
-            MtuRequested?.Invoke(this, new MtuRequestCallbackEventArgs(GetExceptionFromGattStatus(status), mtu));
+
+            IDevice device;
+            if (!_adapter.ConnectedDeviceRegistry.TryGetValue(gatt.Device.Address, out device))
+            {
+                Trace.Message("Device for MTU changed is not in connected list. This should not happen.");
+            }
+
+            MtuRequested?.Invoke(this, new MtuRequestCallbackEventArgs(device, GetExceptionFromGattStatus(status), mtu));
         }
 
         public override void OnReadRemoteRssi(BluetoothGatt gatt, int rssi, GattStatus status)

--- a/Source/Plugin.BLE.Android/Plugin.BLE.Android.csproj
+++ b/Source/Plugin.BLE.Android/Plugin.BLE.Android.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Service.cs" />
     <Compile Include="CallbackEventArgs\DescriptorCallbackEventArgs.cs" />
+    <Compile Include="CallbackEventArgs\MtuRequestCallbackEventArgs.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Plugin.BLE.Abstractions\Plugin.BLE.Abstractions.csproj">

--- a/Source/Plugin.BLE.iOS/Device.cs
+++ b/Source/Plugin.BLE.iOS/Device.cs
@@ -129,5 +129,11 @@ namespace Plugin.BLE.iOS
             //It's maybe not the best idea to updated the name based on CBPeripherial name because this might be stale.
             //Name = nativeDevice.Name; 
         }
+
+        protected override async Task<int> RequestMtuNativeAsync(int requestValue)
+        {
+            Trace.Message($"Request MTU is not supported on iOS.");
+            return await Task.FromResult((int)_nativeDevice.GetMaximumWriteValueLength(CBCharacteristicWriteType.WithoutResponse) - 3);
+        }
     }
 }

--- a/Source/Plugin.BLE.iOS/Device.cs
+++ b/Source/Plugin.BLE.iOS/Device.cs
@@ -133,7 +133,7 @@ namespace Plugin.BLE.iOS
         protected override async Task<int> RequestMtuNativeAsync(int requestValue)
         {
             Trace.Message($"Request MTU is not supported on iOS.");
-            return await Task.FromResult((int)_nativeDevice.GetMaximumWriteValueLength(CBCharacteristicWriteType.WithoutResponse) - 3);
+            return await Task.FromResult((int)_nativeDevice.GetMaximumWriteValueLength(CBCharacteristicWriteType.WithoutResponse));
         }
     }
 }


### PR DESCRIPTION
Hi,

I added the possibility to request an MTU update for a peripheral. 
The requestMTU(int size) method can be called on an iDevice.  After calling it the function will return the new negotiated MTU (which can be differ from your requested one).

Feature Reason:
For iOS the bluetooth "Exchange MTU Request" will be called automatically after connection process. The MTU will be negotiated to about 158bytes for newer devices. Unfortunately on Android this is not done by itself..

There are a few restrictions:
Android < API 21: No such api available. An default value will be returned (-1)
iOS: Not possible to change MTU. The current negotiated MTU will be returned (CBPeripheral.GetMaximumWriteValueLength).

