### PR TITLE
Added possibility to change ConnectionPriority/ ConnectionInterval for Android

### DIFF
--- a/Source/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
+++ b/Source/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
@@ -456,7 +456,8 @@ namespace BLE.Client.ViewModels
                     var resultMTU = await item.Device.RequestMtuAsync(60);
                     System.Diagnostics.Debug.WriteLine($"Requested MTU. Result is {resultMTU}");
 
-                    var resultInterval = await item.Device.UpdateConnectionIntervalAsync(ConnectionInterval.High);
+                    // TODO make this configurable
+                    var resultInterval = item.Device.UpdateConnectionInterval(ConnectionInterval.High);
                     System.Diagnostics.Debug.WriteLine($"Set Connection Interval. Result is {resultInterval}");
 
                     item.Update();

--- a/Source/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
+++ b/Source/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
@@ -456,6 +456,9 @@ namespace BLE.Client.ViewModels
                     var resultMTU = await item.Device.RequestMtuAsync(60);
                     System.Diagnostics.Debug.WriteLine($"Requested MTU. Result is {resultMTU}");
 
+                    var resultInterval = await item.Device.UpdateConnectionIntervalAsync(ConnectionInterval.High);
+                    System.Diagnostics.Debug.WriteLine($"Set Connection Interval. Result is {resultInterval}");
+
                     item.Update();
                     _userDialogs.ShowSuccess($"Connected {item.Device.Name}");
 

--- a/Source/Plugin.BLE.Abstractions/ConnectionInterval.cs
+++ b/Source/Plugin.BLE.Abstractions/ConnectionInterval.cs
@@ -1,5 +1,4 @@
-﻿using System;
-namespace Plugin.BLE.Abstractions
+﻿namespace Plugin.BLE.Abstractions
 {
     public enum ConnectionInterval
     {

--- a/Source/Plugin.BLE.Abstractions/ConnectionInterval.cs
+++ b/Source/Plugin.BLE.Abstractions/ConnectionInterval.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace Plugin.BLE.Abstractions
+{
+    public enum ConnectionInterval
+    {
+        Normal = 0,
+        High = 1,
+        Low = 2 
+    }
+}

--- a/Source/Plugin.BLE.Abstractions/Contracts/IDevice.cs
+++ b/Source/Plugin.BLE.Abstractions/Contracts/IDevice.cs
@@ -89,5 +89,18 @@ namespace Plugin.BLE.Abstractions.Contracts
         /// A task that represents the asynchronous operation. The result contains the negotiated MTU size between master and slave</returns>
         /// <param name="requestValue">The requested MTU</param>
         Task<int> RequestMtuAsync(int requestValue);
+
+        /// <summary>
+        /// Requests a bluetooth-le connection update request. Be aware that this is only implemented on Android (>= API 21). 
+        /// You can choose between a high, low and a normal mode which will requests the following connection intervals: HIGH (11-15ms). NORMAL (30-50ms). LOW (100-125ms).
+        /// Its not possible to request a specific connection interval.
+        /// 
+        /// Important:
+        /// On Android: This function will only work with API level 21 and higher. Other API level will return false as function result.
+        /// On iOS: Updating the connection interval is not supported by iOS. The function simply returns true.
+        /// </summary>
+        /// <returns>True if the update request was sucessfull. On iOS it will always return true.</returns>
+        /// <param name="interval">The requested interval (High/Low/Normal)</param>
+        Task<bool> UpdateConnectionIntervalAsync(ConnectionInterval interval);
     }
 }

--- a/Source/Plugin.BLE.Abstractions/Contracts/IDevice.cs
+++ b/Source/Plugin.BLE.Abstractions/Contracts/IDevice.cs
@@ -101,6 +101,6 @@ namespace Plugin.BLE.Abstractions.Contracts
         /// </summary>
         /// <returns>True if the update request was sucessfull. On iOS it will always return false.</returns>
         /// <param name="interval">The requested interval (High/Low/Normal)</param>
-        Task<bool> UpdateConnectionIntervalAsync(ConnectionInterval interval);
+        bool UpdateConnectionInterval(ConnectionInterval interval);
     }
 }

--- a/Source/Plugin.BLE.Abstractions/Contracts/IDevice.cs
+++ b/Source/Plugin.BLE.Abstractions/Contracts/IDevice.cs
@@ -97,9 +97,9 @@ namespace Plugin.BLE.Abstractions.Contracts
         /// 
         /// Important:
         /// On Android: This function will only work with API level 21 and higher. Other API level will return false as function result.
-        /// On iOS: Updating the connection interval is not supported by iOS. The function simply returns true.
+        /// On iOS: Updating the connection interval is not supported by iOS. The function simply returns false.
         /// </summary>
-        /// <returns>True if the update request was sucessfull. On iOS it will always return true.</returns>
+        /// <returns>True if the update request was sucessfull. On iOS it will always return false.</returns>
         /// <param name="interval">The requested interval (High/Low/Normal)</param>
         Task<bool> UpdateConnectionIntervalAsync(ConnectionInterval interval);
     }

--- a/Source/Plugin.BLE.Abstractions/DeviceBase.cs
+++ b/Source/Plugin.BLE.Abstractions/DeviceBase.cs
@@ -75,10 +75,16 @@ namespace Plugin.BLE.Abstractions
             return await RequestMtuNativeAsync(requestValue);
         }
 
+        public async Task<bool> UpdateConnectionIntervalAsync(ConnectionInterval interval)
+        {
+            return await UpdateConnectionIntervalNativeAsync(interval);
+        }
+
         public abstract Task<bool> UpdateRssiAsync();
         protected abstract DeviceState GetState();
         protected abstract Task<IEnumerable<IService>> GetServicesNativeAsync();
         protected abstract Task<int> RequestMtuNativeAsync(int requestValue);
+        protected abstract Task<bool> UpdateConnectionIntervalNativeAsync(ConnectionInterval interval);
 
         public override string ToString()
         {

--- a/Source/Plugin.BLE.Abstractions/DeviceBase.cs
+++ b/Source/Plugin.BLE.Abstractions/DeviceBase.cs
@@ -75,16 +75,16 @@ namespace Plugin.BLE.Abstractions
             return await RequestMtuNativeAsync(requestValue);
         }
 
-        public async Task<bool> UpdateConnectionIntervalAsync(ConnectionInterval interval)
+        public bool UpdateConnectionInterval(ConnectionInterval interval)
         {
-            return await UpdateConnectionIntervalNativeAsync(interval);
+            return UpdateConnectionIntervalNative(interval);
         }
 
         public abstract Task<bool> UpdateRssiAsync();
         protected abstract DeviceState GetState();
         protected abstract Task<IEnumerable<IService>> GetServicesNativeAsync();
         protected abstract Task<int> RequestMtuNativeAsync(int requestValue);
-        protected abstract Task<bool> UpdateConnectionIntervalNativeAsync(ConnectionInterval interval);
+        protected abstract bool UpdateConnectionIntervalNative(ConnectionInterval interval);
 
         public override string ToString()
         {

--- a/Source/Plugin.BLE.Abstractions/Plugin.BLE.Abstractions.csproj
+++ b/Source/Plugin.BLE.Abstractions/Plugin.BLE.Abstractions.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Utils\BleCommandQueue.cs" />
     <Compile Include="Utils\FakeAdapter.cs" />
     <Compile Include="Utils\TaskBuilder.cs" />
+    <Compile Include="ConnectionInterval.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/Plugin.BLE.Android/Device.cs
+++ b/Source/Plugin.BLE.Android/Device.cs
@@ -319,7 +319,7 @@ namespace Plugin.BLE.Android
             );
         }
 
-        protected override async Task<bool> UpdateConnectionIntervalNativeAsync(ConnectionInterval interval)
+        protected override bool UpdateConnectionIntervalNative(ConnectionInterval interval)
         {
             if (_gatt == null || _gattCallback == null)
             {
@@ -337,7 +337,7 @@ namespace Plugin.BLE.Android
             {
                 // map to android gattConnectionPriorities
                 // https://developer.android.com/reference/android/bluetooth/BluetoothGatt.html#CONNECTION_PRIORITY_BALANCED
-                return await Task.FromResult(_gatt.RequestConnectionPriority((GattConnectionPriority)(int)interval));
+                return _gatt.RequestConnectionPriority((GattConnectionPriority)(int)interval);
             }
             catch(Exception ex)
             {

--- a/Source/Plugin.BLE.Android/Device.cs
+++ b/Source/Plugin.BLE.Android/Device.cs
@@ -321,7 +321,6 @@ namespace Plugin.BLE.Android
 
         protected override async Task<bool> UpdateConnectionIntervalNativeAsync(ConnectionInterval interval)
         {
-
             if (_gatt == null || _gattCallback == null)
             {
                 Trace.Message("You can't update a connection interval for disconnected devices. Device is {0}", State);
@@ -336,6 +335,8 @@ namespace Plugin.BLE.Android
 
             try
             {
+                // map to android gattConnectionPriorities
+                // https://developer.android.com/reference/android/bluetooth/BluetoothGatt.html#CONNECTION_PRIORITY_BALANCED
                 return await Task.FromResult(_gatt.RequestConnectionPriority((GattConnectionPriority)(int)interval));
             }
             catch(Exception ex)

--- a/Source/Plugin.BLE.Android/Device.cs
+++ b/Source/Plugin.BLE.Android/Device.cs
@@ -318,5 +318,30 @@ namespace Plugin.BLE.Android
               unsubscribeReject: handler => _gattCallback.ConnectionInterrupted -= handler
             );
         }
+
+        protected override async Task<bool> UpdateConnectionIntervalNativeAsync(ConnectionInterval interval)
+        {
+
+            if (_gatt == null || _gattCallback == null)
+            {
+                Trace.Message("You can't update a connection interval for disconnected devices. Device is {0}", State);
+                return false;
+            }
+
+            if (Build.VERSION.SdkInt < BuildVersionCodes.Lollipop)
+            {
+                Trace.Message($"Update connection interval paramter in this Android API level");
+                return false;
+            }
+
+            try
+            {
+                return await Task.FromResult(_gatt.RequestConnectionPriority((GattConnectionPriority)(int)interval));
+            }
+            catch(Exception ex)
+            {
+                throw new Exception($"Update Connection Interval fails with error. {ex.Message}");
+            }
+        }
     }
 }

--- a/Source/Plugin.BLE.iOS/Device.cs
+++ b/Source/Plugin.BLE.iOS/Device.cs
@@ -135,5 +135,11 @@ namespace Plugin.BLE.iOS
             Trace.Message($"Request MTU is not supported on iOS.");
             return await Task.FromResult((int)_nativeDevice.GetMaximumWriteValueLength(CBCharacteristicWriteType.WithoutResponse));
         }
+
+        protected override async Task<bool> UpdateConnectionIntervalNativeAsync(ConnectionInterval interval)
+        {
+            Trace.Message("Cannot update connection inteval on iOS. Returning TRUE ..");
+            return await Task.FromResult(true);
+        }
     }
 }

--- a/Source/Plugin.BLE.iOS/Device.cs
+++ b/Source/Plugin.BLE.iOS/Device.cs
@@ -136,10 +136,10 @@ namespace Plugin.BLE.iOS
             return await Task.FromResult((int)_nativeDevice.GetMaximumWriteValueLength(CBCharacteristicWriteType.WithoutResponse));
         }
 
-        protected override Task<bool> UpdateConnectionIntervalNativeAsync(ConnectionInterval interval)
+        protected override bool UpdateConnectionIntervalNative(ConnectionInterval interval)
         {
             Trace.Message("Cannot update connection inteval on iOS.");
-            return Task.FromResult(false);
+            return false;
         }
     }
 }

--- a/Source/Plugin.BLE.iOS/Device.cs
+++ b/Source/Plugin.BLE.iOS/Device.cs
@@ -136,10 +136,10 @@ namespace Plugin.BLE.iOS
             return await Task.FromResult((int)_nativeDevice.GetMaximumWriteValueLength(CBCharacteristicWriteType.WithoutResponse));
         }
 
-        protected override async Task<bool> UpdateConnectionIntervalNativeAsync(ConnectionInterval interval)
+        protected override Task<bool> UpdateConnectionIntervalNativeAsync(ConnectionInterval interval)
         {
-            Trace.Message("Cannot update connection inteval on iOS. Returning TRUE ..");
-            return await Task.FromResult(true);
+            Trace.Message("Cannot update connection inteval on iOS.");
+            return Task.FromResult(false);
         }
     }
 }


### PR DESCRIPTION
Hi,

The Android BLE stack is able to define the connection priority (high, low, balanced) and therefore change the connection interval for a connection.
The connection interval influences the ble performance and battery consumption massively.

**Android Gatt Function:**
https://developer.android.com/reference/android/bluetooth/BluetoothGatt.html#requestConnectionPriority(int)

**Android Settings for Connection Priority:**
https://developer.android.com/reference/android/bluetooth/BluetoothGatt.html#CONNECTION_PRIORITY_BALANCED

Its not available on iOS so this function will only work for Android (and API Level >= 21).
On iOS the call will return TRUE. Why true? I think returning FALSE could lead to unexpected behaviour if somebody reacts on the return value in the consuming app.
Please comment on this.. 



