### PR TITLE
Fixed potential deadlock while discovering services

### DIFF
--- a/Source/Plugin.BLE.iOS/Device.cs
+++ b/Source/Plugin.BLE.iOS/Device.cs
@@ -54,16 +54,16 @@ namespace Plugin.BLE.iOS
                 {
                     Trace.Message("Error while discovering services {0}", args.Error.LocalizedDescription);
                 }
-
-                // why we have to do this check is beyond me. if a service has been discovered, the collection
-                // shouldn't be null, but sometimes it is. le sigh, apple.
+                var services = new Dictionary<CBUUID, IService>();
+                
+                // If args.Error was not null then the Service might be null
                 if (_nativeDevice.Services == null)
                 {
-                    // TODO: review: return? really? Will the Task end?
+                    // No service discovered. Return empty Dictionary.
+                    tcs.TrySetResult(services.Values);
                     return;
                 }
 
-                var services = new Dictionary<CBUUID, IService>();
                 foreach (var s in _nativeDevice.Services)
                 {
                     Trace.Message("Device.Discovered Service: " + s.Description);


### PR DESCRIPTION
The handler function can be called for two reasons: 1) service discovery succeeded or 2) service discovery failed. In the later case `args.Error` will not be null and `_nativeDevice.Services` may be null. In that case, we cannot return from the handler without setting the result on the TaskCompletionSource. Doing so will certainly cause a deadlock because this task will never complete. The fact that the event handler is removed by `_nativeDevice.DiscoveredService -= handler;` ensures that. 

If an error occurs, the code will not complete with an empty list of services. Then the caller can do what they choose with that.