### PR TITLE
[Android] 1.3.0 - GATT operations issue on reconnecting on a previously connected IDevice

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ catch(DeviceConnectionException e)
 
 #### Connect to known Device
 `ConnectToKnownDeviceAsync` can connect to a device by only passing a GUI. This means that if the device GUID is known no scan is neccessary to connect to a device. Very usefull for fast background reconnect.
-Always use a cancellation toke with this method. 
+Always use a cancellation token with this method. 
 - On **iOS** it will attempt to connect indefinately, even if out of range, so the only way to cancel it is with the token.
 - On **Android** this will throw a GATT ERROR in a couple of seconds if the device is out of range.
 

--- a/Source/Plugin.BLE.Android/Characteristic.cs
+++ b/Source/Plugin.BLE.Android/Characteristic.cs
@@ -155,7 +155,7 @@ namespace Plugin.BLE.Android
             Trace.Message("Characteristic.StartUpdates, successful!");
         }
 
-        protected override Task StopUpdatesNativeAsync()
+        protected override async Task StopUpdatesNativeAsync()
         {
             _gattCallback.CharacteristicValueUpdated -= OnCharacteristicValueChanged;
 
@@ -166,7 +166,22 @@ namespace Plugin.BLE.Android
             if (!successful)
                 throw new CharacteristicReadException("GATT: SetCharacteristicNotification to false, FAILED.");
 
-            return Task.FromResult(true);
+            if (_nativeCharacteristic.Descriptors.Count > 0)
+            {
+                var descriptors = await GetDescriptorsAsync();
+                var descriptor = descriptors.FirstOrDefault(d => d.Id.Equals(ClientCharacteristicConfigurationDescriptorId)) ??
+                                            descriptors.FirstOrDefault(); // fallback just in case manufacturer forgot
+
+                if (Properties.HasFlag(CharacteristicPropertyType.Notify))
+                {
+                    await descriptor.WriteAsync(BluetoothGattDescriptor.DisableNotificationValue.ToArray());
+                    Trace.Message("Descriptor set value: DISABLE_NOTIFY");
+                }
+            }
+            else
+            {
+                Trace.Message("Descriptor set value FAILED: _nativeCharacteristic.Descriptors was empty");
+            }
         }
 
         private void OnCharacteristicValueChanged(object sender, CharacteristicReadCallbackEventArgs e)

--- a/Source/Plugin.BLE.Android/GattCallback.cs
+++ b/Source/Plugin.BLE.Android/GattCallback.cs
@@ -62,7 +62,9 @@ namespace Plugin.BLE.Android
 
                     // Close GATT regardless, else we can accumulate zombie gatts.
                     CloseGattInstances(gatt);
-
+                    // Clear services & characteristics otherwise we will get gatt operation return FALSE when connecting to the same IDevice instace at a later time
+                    _device.ClearServices();
+                     
                     if (_device.IsOperationRequested)
                     {
                         Trace.Message("Disconnected by user");


### PR DESCRIPTION
This is a fix for Android when reconnecting to a previously connected IDevice, any GATT operations would return FALSE because the services & characteristics cache is no longer valid.

I am simply calling DeviceBase.ClearServices() (as it is in iOS) when device is disconnected (lost or intentionnaly).

I've also merge my PR for Issue #227 into the 1.3.0 branch.