### PR TITLE
[UWP]Use Adapter.ScanMode to set UWP's  ScanningMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ Add this line to your manifest if you want to declare that your app is available
 <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
 ````
 
+**UWP**
+
+Add this line to the Package Manifest (.appxmanifest):
+
+```xml
+<DeviceCapability Name="bluetooth" />
+```
+
 ## Sample app
 
 We provide a sample Xamarin.Forms app, that is a basic bluetooth LE scanner. With this app, it's possible to 

--- a/Source/BLE.Client.UWP/BLE.Client.UWP.csproj
+++ b/Source/BLE.Client.UWP/BLE.Client.UWP.csproj
@@ -133,7 +133,7 @@
       <Version>6.5.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>5.2.3</Version>
+      <Version>5.4.0</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross">
       <Version>5.1.0</Version>

--- a/Source/BLE.Client.UWP/Package.appxmanifest
+++ b/Source/BLE.Client.UWP/Package.appxmanifest
@@ -45,5 +45,6 @@
 
   <Capabilities>
     <Capability Name="internetClient" />
+    <DeviceCapability Name="bluetooth" />
   </Capabilities>
 </Package>

--- a/Source/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
+++ b/Source/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
@@ -43,7 +43,7 @@ namespace BLE.Client.ViewModels
         public MvxCommand<DeviceListItemViewModel> ConnectDisposeCommand => new MvxCommand<DeviceListItemViewModel>(ConnectAndDisposeDevice);
 
         public ObservableCollection<DeviceListItemViewModel> Devices { get; set; } = new ObservableCollection<DeviceListItemViewModel>();
-        public bool IsRefreshing => Adapter.IsScanning;
+        public bool IsRefreshing => (Adapter != null) ? Adapter.IsScanning : false;
         public bool IsStateOn => _bluetoothLe.IsOn;
         public string StateText => GetStateText();
         public DeviceListItemViewModel SelectedDevice

--- a/Source/Plugin.BLE.Abstractions/ConnectParameter.cs
+++ b/Source/Plugin.BLE.Abstractions/ConnectParameter.cs
@@ -6,7 +6,7 @@
     public struct ConnectParameters
     {
         /// <summary>
-        /// Android only, from documnetation:  
+        /// Android only, from documentation:  
         /// boolean: Whether to directly connect to the remote device (false) or to automatically connect as soon as the remote device becomes available (true).
         /// </summary>
         public bool AutoConnect { get; }

--- a/Source/Plugin.BLE.Abstractions/Contracts/IAdapter.cs
+++ b/Source/Plugin.BLE.Abstractions/Contracts/IAdapter.cs
@@ -26,11 +26,11 @@ namespace Plugin.BLE.Abstractions.Contracts
         /// </summary>
         event EventHandler<DeviceEventArgs> DeviceConnected;
         /// <summary>
-        /// Occurs when a device has been disconnected. This occurs on intendet disconnects after <see cref="DisconnectDeviceAsync"/>.
+        /// Occurs when a device has been disconnected. This occurs on intended disconnects after <see cref="DisconnectDeviceAsync"/>.
         /// </summary>
         event EventHandler<DeviceEventArgs> DeviceDisconnected;
         /// <summary>
-        /// Occurs when a device has been disconnected. This occurs on unintendet disconnects (e.g. when the device exploded).
+        /// Occurs when a device has been disconnected. This occurs on unintended disconnects (e.g. when the device exploded).
         /// </summary>
         event EventHandler<DeviceErrorEventArgs> DeviceConnectionLost;
         /// <summary>

--- a/Source/Plugin.BLE.UWP/Adapter.cs
+++ b/Source/Plugin.BLE.UWP/Adapter.cs
@@ -79,23 +79,47 @@ namespace Plugin.BLE.UWP
 
         protected async override Task ConnectToDeviceNativeAsync(IDevice device, ConnectParameters connectParameters, CancellationToken cancellationToken)
         {
-            var uwpDevice = (Device)device;
             Trace.Message($"Connecting to device with ID:  {device.Id.ToString()}");
-            await ((ObservableBluetoothLEDevice)uwpDevice.NativeDevice).ConnectAsync();
+
+            ObservableBluetoothLEDevice nativeDevice = device.NativeDevice as ObservableBluetoothLEDevice;
+            if (nativeDevice == null)
+                return;
+
+            nativeDevice.PropertyChanged += Device_PropertyChanged;
+
+            await nativeDevice.ConnectAsync();
+
+            var uwpDevice = (Device)device;
             if (!ConnectedDeviceRegistry.ContainsKey(uwpDevice.Id.ToString()))
-            {
                 ConnectedDeviceRegistry.Add(uwpDevice.Id.ToString(), device);
-            }
-            await Task.Delay(100); //wait for windows to add services to the device
-            HandleConnectedDevice(device);
+        }
+
+        private void Device_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName != "IsConnected")
+                return;
+
+            ObservableBluetoothLEDevice nativeDevice = sender as ObservableBluetoothLEDevice;
+            if (nativeDevice == null)
+                return;
+
+            Guid id = new Device(this, nativeDevice.BluetoothLEDevice, 0, String.Empty).Id;
+
+            ConnectedDeviceRegistry.TryGetValue(id.ToString(), out IDevice device);
+            if (device == null)
+                return;
+
+            if (nativeDevice.IsConnected)
+                HandleConnectedDevice(device);
+            else
+                HandleDisconnectedDevice(false, device);
         }
 
         protected override void DisconnectDeviceNative(IDevice device)
         {
-            //windows doesn't support disconnecting, so currently just disposes of device
+            // Windows doesn't support disconnecting, so currently just dispose of the device
             Trace.Message($"Disconnected from device with ID:  {device.Id.ToString()}");
             ConnectedDeviceRegistry.Remove(device.Id.ToString());
-            HandleDisconnectedDevice(true, device);
         }
 
         public async override Task<IDevice> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters, CancellationToken cancellationToken)

--- a/Source/Plugin.BLE.UWP/Adapter.cs
+++ b/Source/Plugin.BLE.UWP/Adapter.cs
@@ -85,31 +85,18 @@ namespace Plugin.BLE.UWP
             if (nativeDevice == null)
                 return;
 
-            nativeDevice.PropertyChanged += Device_PropertyChanged;
+            var uwpDevice = (Device)device;
+            uwpDevice.ConnectionStatusChanged += Device_ConnectionStatusChanged;
 
             await nativeDevice.ConnectAsync();
 
-            var uwpDevice = (Device)device;
             if (!ConnectedDeviceRegistry.ContainsKey(uwpDevice.Id.ToString()))
                 ConnectedDeviceRegistry.Add(uwpDevice.Id.ToString(), device);
         }
 
-        private void Device_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void Device_ConnectionStatusChanged(Device device, BluetoothConnectionStatus status)
         {
-            if (e.PropertyName != "IsConnected")
-                return;
-
-            ObservableBluetoothLEDevice nativeDevice = sender as ObservableBluetoothLEDevice;
-            if (nativeDevice == null)
-                return;
-
-            Guid id = new Device(this, nativeDevice.BluetoothLEDevice, 0, String.Empty).Id;
-
-            ConnectedDeviceRegistry.TryGetValue(id.ToString(), out IDevice device);
-            if (device == null)
-                return;
-
-            if (nativeDevice.IsConnected)
+            if (status == BluetoothConnectionStatus.Connected)
                 HandleConnectedDevice(device);
             else
                 HandleDisconnectedDevice(false, device);

--- a/Source/Plugin.BLE.UWP/Adapter.cs
+++ b/Source/Plugin.BLE.UWP/Adapter.cs
@@ -39,7 +39,6 @@ namespace Plugin.BLE.UWP
             var hasFilter = serviceUuids?.Any() ?? false;
             DiscoveredDevices.Clear();
             _BleWatcher = new BluetoothLEAdvertisementWatcher();
-            _BleWatcher.ScanningMode = BluetoothLEScanningMode.Active;
             _prevScannedDevices = new List<ulong>();
             Trace.Message("Starting a scan for devices.");
             if (hasFilter)

--- a/Source/Plugin.BLE.UWP/Adapter.cs
+++ b/Source/Plugin.BLE.UWP/Adapter.cs
@@ -9,6 +9,7 @@ using Plugin.BLE.Abstractions.Contracts;
 using System.Threading;
 using Microsoft.Toolkit.Uwp;
 using System.Runtime.InteropServices.WindowsRuntime;
+using Plugin.BLE.Extensions;
 
 namespace Plugin.BLE.UWP
 {
@@ -38,7 +39,10 @@ namespace Plugin.BLE.UWP
         {
             var hasFilter = serviceUuids?.Any() ?? false;
             DiscoveredDevices.Clear();
-            _BleWatcher = new BluetoothLEAdvertisementWatcher();
+            _BleWatcher = new BluetoothLEAdvertisementWatcher
+            {
+                ScanningMode = ScanMode.ToNative()
+            };
             _prevScannedDevices = new List<ulong>();
             Trace.Message("Starting a scan for devices.");
             if (hasFilter)

--- a/Source/Plugin.BLE.UWP/Adapter.cs
+++ b/Source/Plugin.BLE.UWP/Adapter.cs
@@ -1,14 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading;
 using System.Threading.Tasks;
+
+using Microsoft.Toolkit.Uwp.Connectivity;
 using Windows.Devices.Bluetooth;
 using Windows.Devices.Bluetooth.Advertisement;
+
 using Plugin.BLE.Abstractions;
 using Plugin.BLE.Abstractions.Contracts;
-using System.Threading;
-using Microsoft.Toolkit.Uwp;
-using System.Runtime.InteropServices.WindowsRuntime;
 using Plugin.BLE.Extensions;
 
 namespace Plugin.BLE.UWP

--- a/Source/Plugin.BLE.UWP/BleImplementation.cs
+++ b/Source/Plugin.BLE.UWP/BleImplementation.cs
@@ -1,7 +1,7 @@
 ﻿using Plugin.BLE.Abstractions;
 using Plugin.BLE.Abstractions.Contracts;
 using Plugin.BLE.UWP;
-using Microsoft.Toolkit.Uwp;
+using Microsoft.Toolkit.Uwp.Connectivity;
 
 namespace Plugin.BLE
 {

--- a/Source/Plugin.BLE.UWP/Device.cs
+++ b/Source/Plugin.BLE.UWP/Device.cs
@@ -2,10 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+
+using Microsoft.Toolkit.Uwp.Connectivity;
 using Windows.Devices.Bluetooth;
+
 using Plugin.BLE.Abstractions;
 using Plugin.BLE.Abstractions.Contracts;
-using Microsoft.Toolkit.Uwp;
 
 namespace Plugin.BLE.UWP
 {

--- a/Source/Plugin.BLE.UWP/Device.cs
+++ b/Source/Plugin.BLE.UWP/Device.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -23,6 +24,18 @@ namespace Plugin.BLE.UWP
             Id = ParseDeviceId(nativeDevice.BluetoothAddress.ToString("x"));
             Name = nativeDevice.Name;
             AdvertisementRecords = advertisementRecords;
+            _nativeDevice.PropertyChanged += NativeDevice_PropertyChanged;
+        }
+
+        public delegate void ConnectionStatusChangedHandler(Device device, BluetoothConnectionStatus status);
+        public ConnectionStatusChangedHandler ConnectionStatusChanged;
+
+        private void NativeDevice_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName != "IsConnected")
+                return;
+
+            ConnectionStatusChanged?.Invoke(this, _nativeDevice.BluetoothLEDevice.ConnectionStatus);
         }
 
         /// <summary>

--- a/Source/Plugin.BLE.UWP/Extensions/ScanModeExtension.cs
+++ b/Source/Plugin.BLE.UWP/Extensions/ScanModeExtension.cs
@@ -1,0 +1,28 @@
+using System;
+using Windows.Devices.Bluetooth.Advertisement;
+using Plugin.BLE.Abstractions.Contracts;
+using Trace = Plugin.BLE.Abstractions.Trace;
+
+namespace Plugin.BLE.Extensions
+{
+    /// <summary>
+    /// See https://github.com/xabre/xamarin-bluetooth-le/blob/master/doc/scanmode_mapping.md
+    /// </summary>
+    internal static class ScanModeExtension
+    {
+        public static BluetoothLEScanningMode ToNative(this ScanMode scanMode)
+        {
+            switch (scanMode)
+            {
+                case ScanMode.Passive:
+                    return BluetoothLEScanningMode.Passive;
+                case ScanMode.LowPower:
+                case ScanMode.Balanced:
+                case ScanMode.LowLatency:
+                    return BluetoothLEScanningMode.Active;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(scanMode), scanMode, null);
+            }
+        }
+    }
+}

--- a/Source/Plugin.BLE.UWP/Plugin.BLE.UWP.csproj
+++ b/Source/Plugin.BLE.UWP/Plugin.BLE.UWP.csproj
@@ -113,6 +113,7 @@
     <Compile Include="DefaultTrace.cs" />
     <Compile Include="Descriptor.cs" />
     <Compile Include="Device.cs" />
+    <Compile Include="Extensions\ScanModeExtension.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Service.cs" />
     <EmbeddedResource Include="Properties\Plugin.BLE.UWP.rd.xml">

--- a/Source/Plugin.BLE.UWP/Plugin.BLE.UWP.csproj
+++ b/Source/Plugin.BLE.UWP/Plugin.BLE.UWP.csproj
@@ -122,7 +122,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>5.3.3</Version>
+      <Version>5.4.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp">
       <Version>1.5.0</Version>

--- a/Source/Plugin.BLE.UWP/Plugin.BLE.UWP.csproj
+++ b/Source/Plugin.BLE.UWP/Plugin.BLE.UWP.csproj
@@ -124,8 +124,8 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>5.4.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Toolkit.Uwp">
-      <Version>1.5.0</Version>
+    <PackageReference Include="Microsoft.Toolkit.Uwp.Connectivity">
+      <Version>2.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Source/Plugin.BLE.UWP/Service.cs
+++ b/Source/Plugin.BLE.UWP/Service.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+
+using Microsoft.Toolkit.Uwp.Connectivity;
 using Windows.Devices.Bluetooth.GenericAttributeProfile;
+
 using Plugin.BLE.Abstractions;
 using Plugin.BLE.Abstractions.Contracts;
-using Microsoft.Toolkit.Uwp;
 
 namespace Plugin.BLE.UWP
 {


### PR DESCRIPTION
During my test, ~~if `ScanningMode = BluetoothLEScanningMode.Active` I got no device scanned.
But if `ScanningMode = BluetoothLEScanningMode.Passive` (default value), I got device list same as the result of Android/iOS.~~
EDIT: I tested again the other day, the Thinkpad E450 can scan my devices at `Active` mode. 

Another example is from https://github.com/Microsoft/Windows-universal-samples/blob/master/Samples/BluetoothAdvertisement/cs/Scenario1_Watcher.xaml.cs and it uses the default (`Passive`) value. 