### PR TITLE
Issue #245 Fix: Add CancellationToken parameters to *NativeAsync methods

### DIFF
--- a/Source/Plugin.BLE.Abstractions/CharacteristicBase.cs
+++ b/Source/Plugin.BLE.Abstractions/CharacteristicBase.cs
@@ -71,7 +71,7 @@ namespace Plugin.BLE.Abstractions
             }
 
             Trace.Message("Characteristic.ReadAsync");
-            return await ReadNativeAsync();
+            return await ReadNativeAsync(cancellationToken);
         }
 
         public async Task<bool> WriteAsync(byte[] data, CancellationToken cancellationToken = default(CancellationToken))
@@ -89,7 +89,7 @@ namespace Plugin.BLE.Abstractions
             var writeType = GetWriteType();
 
             Trace.Message("Characteristic.WriteAsync");
-            return await WriteNativeAsync(data, writeType);
+            return await WriteNativeAsync(data, writeType, cancellationToken);
         }
 
         private CharacteristicWriteType GetWriteType()
@@ -102,7 +102,7 @@ namespace Plugin.BLE.Abstractions
                 CharacteristicWriteType.WithoutResponse;
         }
 
-        public Task StartUpdatesAsync()
+        public Task StartUpdatesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             if (!CanUpdate)
             {
@@ -110,36 +110,36 @@ namespace Plugin.BLE.Abstractions
             }
 
             Trace.Message("Characteristic.StartUpdates");
-            return StartUpdatesNativeAsync();
+            return StartUpdatesNativeAsync(cancellationToken);
         }
 
-        public Task StopUpdatesAsync()
+        public Task StopUpdatesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             if (!CanUpdate)
             {
                 throw new InvalidOperationException("Characteristic does not support update.");
             }
 
-            return StopUpdatesNativeAsync();
+            return StopUpdatesNativeAsync(cancellationToken);
         }
 
         public async Task<IList<IDescriptor>> GetDescriptorsAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             if (_descriptors == null)
-                _descriptors = await GetDescriptorsNativeAsync();
+                _descriptors = await GetDescriptorsNativeAsync(cancellationToken);
             return _descriptors;
         }
 
         public async Task<IDescriptor> GetDescriptorAsync(Guid id, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var descriptors = await GetDescriptorsAsync().ConfigureAwait(false);
+            var descriptors = await GetDescriptorsAsync(cancellationToken);
             return descriptors.FirstOrDefault(d => d.Id == id);
         }
 
-        protected abstract Task<IList<IDescriptor>> GetDescriptorsNativeAsync();
-        protected abstract Task<byte[]> ReadNativeAsync();
-        protected abstract Task<bool> WriteNativeAsync(byte[] data, CharacteristicWriteType writeType);
-        protected abstract Task StartUpdatesNativeAsync();
-        protected abstract Task StopUpdatesNativeAsync();
+        protected abstract Task<IList<IDescriptor>> GetDescriptorsNativeAsync(CancellationToken cancellationToken = default(CancellationToken));
+        protected abstract Task<byte[]> ReadNativeAsync(CancellationToken cancellationToken = default(CancellationToken));
+        protected abstract Task<bool> WriteNativeAsync(byte[] data, CharacteristicWriteType writeType, CancellationToken cancellationToken = default(CancellationToken));
+        protected abstract Task StartUpdatesNativeAsync(CancellationToken cancellationToken = default(CancellationToken));
+        protected abstract Task StopUpdatesNativeAsync(CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/Source/Plugin.BLE.Abstractions/CharacteristicBase.cs
+++ b/Source/Plugin.BLE.Abstractions/CharacteristicBase.cs
@@ -132,7 +132,7 @@ namespace Plugin.BLE.Abstractions
 
         public async Task<IDescriptor> GetDescriptorAsync(Guid id, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var descriptors = await GetDescriptorsAsync(cancellationToken);
+            var descriptors = await GetDescriptorsAsync(cancellationToken).ConfigureAwait(false);
             return descriptors.FirstOrDefault(d => d.Id == id);
         }
 

--- a/Source/Plugin.BLE.Abstractions/Contracts/ICharacteristic.cs
+++ b/Source/Plugin.BLE.Abstractions/Contracts/ICharacteristic.cs
@@ -104,13 +104,13 @@ namespace Plugin.BLE.Abstractions.Contracts
         /// </summary>
         /// <exception cref="InvalidOperationException">Thrown if characteristic doesn't support notify. See: <see cref="CanUpdate"/></exception>
         /// <exception cref="Exception">Thrown if an error occurs while starting notifications </exception>
-        Task StartUpdatesAsync();
+        Task StartUpdatesAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Stops listening for notify events on this characteristic.
         /// <exception cref="Exception">Thrown if an error occurs while starting notifications </exception>
         /// </summary>
-        Task StopUpdatesAsync();
+        Task StopUpdatesAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Gets the descriptors of the characteristic.

--- a/Source/Plugin.BLE.Abstractions/Contracts/IService.cs
+++ b/Source/Plugin.BLE.Abstractions/Contracts/IService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Plugin.BLE.Abstractions.Contracts
@@ -34,7 +35,7 @@ namespace Plugin.BLE.Abstractions.Contracts
         /// Gets the characteristics of the service.
         /// </summary>
         /// <returns>A task that represents the asynchronous read operation. The Result property will contain a list of characteristics.</returns>
-        Task<IList<ICharacteristic>> GetCharacteristicsAsync();
+        Task<IList<ICharacteristic>> GetCharacteristicsAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Gets the first characteristic with the Id <paramref name="id"/>. 
@@ -45,6 +46,6 @@ namespace Plugin.BLE.Abstractions.Contracts
         /// The Result property will contain the characteristic with the specified <paramref name="id"/>.
         /// If the characteristic doesn't exist, the Result will be null.
         /// </returns>
-        Task<ICharacteristic> GetCharacteristicAsync(Guid id);
+        Task<ICharacteristic> GetCharacteristicAsync(Guid id, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/Source/Plugin.BLE.Abstractions/DescriptorBase.cs
+++ b/Source/Plugin.BLE.Abstractions/DescriptorBase.cs
@@ -24,10 +24,10 @@ namespace Plugin.BLE.Abstractions
 
         public Task<byte[]> ReadAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            return ReadNativeAsync();
+            return ReadNativeAsync(cancellationToken);
         }
 
-        protected abstract Task<byte[]> ReadNativeAsync();
+        protected abstract Task<byte[]> ReadNativeAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         public Task WriteAsync(byte[] data, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -36,10 +36,10 @@ namespace Plugin.BLE.Abstractions
                 throw new ArgumentNullException(nameof(data));
             }
 
-            return WriteNativeAsync(data);
+            return WriteNativeAsync(data, cancellationToken);
         }
 
-        protected abstract Task WriteNativeAsync(byte[] data);
+        protected abstract Task WriteNativeAsync(byte[] data, CancellationToken cancellationToken = default(CancellationToken));
 
 
 

--- a/Source/Plugin.BLE.Abstractions/DeviceBase.cs
+++ b/Source/Plugin.BLE.Abstractions/DeviceBase.cs
@@ -57,7 +57,7 @@ namespace Plugin.BLE.Abstractions
             {
                 using (var source = this.GetCombinedSource(cancellationToken))
                 {
-                    KnownServices.AddRange(await GetServicesNativeAsync());
+                    KnownServices.AddRange(await GetServicesNativeAsync(cancellationToken));
                 }
             }
 
@@ -82,7 +82,7 @@ namespace Plugin.BLE.Abstractions
 
         public abstract Task<bool> UpdateRssiAsync();
         protected abstract DeviceState GetState();
-        protected abstract Task<IEnumerable<IService>> GetServicesNativeAsync();
+        protected abstract Task<IEnumerable<IService>> GetServicesNativeAsync(CancellationToken cancellationToken = default(CancellationToken));
         protected abstract Task<int> RequestMtuNativeAsync(int requestValue);
         protected abstract bool UpdateConnectionIntervalNative(ConnectionInterval interval);
 

--- a/Source/Plugin.BLE.Abstractions/ServiceBase.cs
+++ b/Source/Plugin.BLE.Abstractions/ServiceBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Plugin.BLE.Abstractions.Contracts;
+using System.Threading;
 
 namespace Plugin.BLE.Abstractions
 {
@@ -20,24 +21,24 @@ namespace Plugin.BLE.Abstractions
             Device = device;
         }
 
-        public async Task<IList<ICharacteristic>> GetCharacteristicsAsync()
+        public async Task<IList<ICharacteristic>> GetCharacteristicsAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             if (!_characteristics.Any())
             {    
-                _characteristics.AddRange(await GetCharacteristicsNativeAsync());
+                _characteristics.AddRange(await GetCharacteristicsNativeAsync(cancellationToken));
             }
 
             // make a copy here so that the caller cant modify the original list
             return _characteristics.ToList();
         }
         
-        public async Task<ICharacteristic> GetCharacteristicAsync(Guid id)
+        public async Task<ICharacteristic> GetCharacteristicAsync(Guid id, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var characteristics = await GetCharacteristicsAsync();
+            var characteristics = await GetCharacteristicsAsync(cancellationToken);
             return characteristics.FirstOrDefault(c => c.Id == id);
         }
 
-        protected abstract Task<IList<ICharacteristic>> GetCharacteristicsNativeAsync();
+        protected abstract Task<IList<ICharacteristic>> GetCharacteristicsNativeAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         public virtual void Dispose()
         {

--- a/Source/Plugin.BLE.Android/Descriptor.cs
+++ b/Source/Plugin.BLE.Android/Descriptor.cs
@@ -5,6 +5,7 @@ using Plugin.BLE.Abstractions;
 using Plugin.BLE.Abstractions.Contracts;
 using Plugin.BLE.Abstractions.Utils;
 using Plugin.BLE.Android.CallbackEventArgs;
+using System.Threading;
 
 namespace Plugin.BLE.Android
 {
@@ -25,7 +26,7 @@ namespace Plugin.BLE.Android
             _nativeDescriptor = nativeDescriptor;
         }
 
-        protected override Task WriteNativeAsync(byte[] data)
+        protected override Task WriteNativeAsync(byte[] data, CancellationToken cancellationToken = default(CancellationToken))
         {
             return TaskBuilder.FromEvent<bool, EventHandler<DescriptorCallbackEventArgs>, EventHandler>(
                execute: () => InternalWrite(data),
@@ -46,7 +47,8 @@ namespace Plugin.BLE.Android
                    reject(new Exception($"Device '{Characteristic.Service.Device.Id}' disconnected while writing descriptor with {Id}."));
                }),
                subscribeReject: handler => _gattCallback.ConnectionInterrupted += handler,
-               unsubscribeReject: handler => _gattCallback.ConnectionInterrupted -= handler);
+               unsubscribeReject: handler => _gattCallback.ConnectionInterrupted -= handler,
+               token: cancellationToken);
         }
 
         private void InternalWrite(byte[] data)
@@ -58,7 +60,7 @@ namespace Plugin.BLE.Android
                 throw new Exception("GATT: WRITE descriptor value failed");
         }
 
-        protected override async Task<byte[]> ReadNativeAsync()
+        protected override async Task<byte[]> ReadNativeAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return await TaskBuilder.FromEvent<byte[], EventHandler<DescriptorCallbackEventArgs>, EventHandler>(
                execute: ReadInternal,
@@ -76,7 +78,8 @@ namespace Plugin.BLE.Android
                    reject(new Exception($"Device '{Characteristic.Service.Device.Id}' disconnected while reading descripor with {Id}."));
                }),
                subscribeReject: handler => _gattCallback.ConnectionInterrupted += handler,
-               unsubscribeReject: handler => _gattCallback.ConnectionInterrupted -= handler);
+               unsubscribeReject: handler => _gattCallback.ConnectionInterrupted -= handler,
+               token: cancellationToken);
         }
 
         private void ReadInternal()

--- a/Source/Plugin.BLE.Android/Device.cs
+++ b/Source/Plugin.BLE.Android/Device.cs
@@ -13,6 +13,7 @@ using Plugin.BLE.Abstractions.Exceptions;
 using Plugin.BLE.Abstractions.Utils;
 using Plugin.BLE.Android.CallbackEventArgs;
 using Trace = Plugin.BLE.Abstractions.Trace;
+using System.Threading;
 
 namespace Plugin.BLE.Android
 {
@@ -53,7 +54,7 @@ namespace Plugin.BLE.Android
         public override object NativeDevice => BluetoothDevice;
         internal bool IsOperationRequested { get; set; }
 
-        protected override async Task<IEnumerable<IService>> GetServicesNativeAsync()
+        protected override async Task<IEnumerable<IService>> GetServicesNativeAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             if (_gattCallback == null || _gatt == null)
             {
@@ -73,7 +74,8 @@ namespace Plugin.BLE.Android
                     reject(new Exception($"Device {Name} disconnected while fetching services."));
                 }),
                 subscribeReject: handler => _gattCallback.ConnectionInterrupted += handler,
-                unsubscribeReject: handler => _gattCallback.ConnectionInterrupted -= handler);
+                unsubscribeReject: handler => _gattCallback.ConnectionInterrupted -= handler,
+                token: cancellationToken);
         }
 
         public void Connect(ConnectParameters connectParameters)

--- a/Source/Plugin.BLE.Android/Service.cs
+++ b/Source/Plugin.BLE.Android/Service.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Android.Bluetooth;
 using Plugin.BLE.Abstractions;
 using Plugin.BLE.Abstractions.Contracts;
+using System.Threading;
 
 namespace Plugin.BLE.Android
 {
@@ -24,7 +25,7 @@ namespace Plugin.BLE.Android
             _gattCallback = gattCallback;
         }
 
-        protected override Task<IList<ICharacteristic>> GetCharacteristicsNativeAsync()
+        protected override Task<IList<ICharacteristic>> GetCharacteristicsNativeAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.FromResult<IList<ICharacteristic>>(
                 _nativeService.Characteristics.Select(characteristic => new Characteristic(characteristic, _gatt, _gattCallback, this))

--- a/Source/Plugin.BLE.Tests/Mocks/CharacteristicMock.cs
+++ b/Source/Plugin.BLE.Tests/Mocks/CharacteristicMock.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Plugin.BLE.Abstractions;
 using Plugin.BLE.Abstractions.Contracts;
 using Plugin.BLE.Abstractions.EventArgs;
+using System.Threading;
 
 namespace Plugin.BLE.Tests.Mocks
 {
@@ -37,28 +38,28 @@ namespace Plugin.BLE.Tests.Mocks
 
         public override CharacteristicPropertyType Properties => MockPropterties;
 
-        protected override Task<IList<IDescriptor>> GetDescriptorsNativeAsync()
+        protected override Task<IList<IDescriptor>> GetDescriptorsNativeAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             throw new NotImplementedException();
         }
 
-        protected override Task<byte[]> ReadNativeAsync()
+        protected override Task<byte[]> ReadNativeAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             throw new NotImplementedException();
         }
 
-        protected override Task<bool> WriteNativeAsync(byte[] data, CharacteristicWriteType writeType)
+        protected override Task<bool> WriteNativeAsync(byte[] data, CharacteristicWriteType writeType, CancellationToken cancellationToken = default(CancellationToken))
         {
             WriteHistory.Add(new WriteOperation(data, writeType));
             return Task.FromResult(true);
         }
 
-        protected override Task StartUpdatesNativeAsync()
+        protected override Task StartUpdatesNativeAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             throw new NotImplementedException();
         }
 
-        protected override Task StopUpdatesNativeAsync()
+        protected override Task StopUpdatesNativeAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             throw new NotImplementedException();
         }

--- a/Source/Plugin.BLE.iOS/Characteristic.cs
+++ b/Source/Plugin.BLE.iOS/Characteristic.cs
@@ -11,6 +11,7 @@ using Plugin.BLE.Abstractions.Exceptions;
 using Plugin.BLE.Abstractions.Extensions;
 using Plugin.BLE.Abstractions.Utils;
 using Plugin.BLE.Extensions;
+using System.Threading;
 
 namespace Plugin.BLE.iOS
 {
@@ -45,7 +46,7 @@ namespace Plugin.BLE.iOS
             _parentDevice = parentDevice;
         }
 
-        protected override Task<IList<IDescriptor>> GetDescriptorsNativeAsync()
+        protected override Task<IList<IDescriptor>> GetDescriptorsNativeAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return TaskBuilder.FromEvent<IList<IDescriptor>, EventHandler<CBCharacteristicEventArgs>>(
                 execute: () => _parentDevice.DiscoverDescriptors(_nativeCharacteristic),
@@ -64,10 +65,11 @@ namespace Plugin.BLE.iOS
                         }
                     },
                 subscribeComplete: handler => _parentDevice.DiscoveredDescriptor += handler,
-                unsubscribeComplete: handler => _parentDevice.DiscoveredDescriptor -= handler);
+                unsubscribeComplete: handler => _parentDevice.DiscoveredDescriptor -= handler,
+                token: cancellationToken);
         }
 
-        protected override Task<byte[]> ReadNativeAsync()
+        protected override Task<byte[]> ReadNativeAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return TaskBuilder.FromEvent<byte[], EventHandler<CBCharacteristicEventArgs>>(
                     execute: () => _parentDevice.ReadValue(_nativeCharacteristic),
@@ -87,10 +89,11 @@ namespace Plugin.BLE.iOS
                         }
                     },
                     subscribeComplete: handler => _parentDevice.UpdatedCharacterteristicValue += handler,
-                    unsubscribeComplete: handler => _parentDevice.UpdatedCharacterteristicValue -= handler);
+                    unsubscribeComplete: handler => _parentDevice.UpdatedCharacterteristicValue -= handler,
+                    token: cancellationToken);
         }
 
-        protected override Task<bool> WriteNativeAsync(byte[] data, CharacteristicWriteType writeType)
+        protected override Task<bool> WriteNativeAsync(byte[] data, CharacteristicWriteType writeType, CancellationToken cancellationToken = default(CancellationToken))
         {
             Task<bool> task;
 
@@ -107,7 +110,8 @@ namespace Plugin.BLE.iOS
                         complete(args.Error == null);
                     },
                     subscribeComplete: handler => _parentDevice.WroteCharacteristicValue += handler,
-                    unsubscribeComplete: handler => _parentDevice.WroteCharacteristicValue -= handler);
+                    unsubscribeComplete: handler => _parentDevice.WroteCharacteristicValue -= handler,
+                    token:  cancellationToken);
             }
             else
             {
@@ -120,7 +124,7 @@ namespace Plugin.BLE.iOS
             return task;
         }
 
-        protected override Task StartUpdatesNativeAsync()
+        protected override Task StartUpdatesNativeAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             _parentDevice.UpdatedCharacterteristicValue -= UpdatedNotify;
             _parentDevice.UpdatedCharacterteristicValue += UpdatedNotify;
@@ -144,10 +148,11 @@ namespace Plugin.BLE.iOS
                       }
                   },
                subscribeComplete: handler => _parentDevice.UpdatedNotificationState += handler,
-                  unsubscribeComplete: handler => _parentDevice.UpdatedNotificationState -= handler);
+                  unsubscribeComplete: handler => _parentDevice.UpdatedNotificationState -= handler,
+               token: cancellationToken);
         }
 
-        protected override Task StopUpdatesNativeAsync()
+        protected override Task StopUpdatesNativeAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             _parentDevice.UpdatedCharacterteristicValue -= UpdatedNotify;
             return TaskBuilder.FromEvent<bool, EventHandler<CBCharacteristicEventArgs>>(
@@ -168,7 +173,8 @@ namespace Plugin.BLE.iOS
                       }
                   },
                 subscribeComplete: handler => _parentDevice.UpdatedNotificationState += handler,
-                unsubscribeComplete: handler => _parentDevice.UpdatedNotificationState -= handler);
+                unsubscribeComplete: handler => _parentDevice.UpdatedNotificationState -= handler,
+                token: cancellationToken);
         }
 
         private void UpdatedNotify(object sender, CBCharacteristicEventArgs e)

--- a/Source/Plugin.BLE.iOS/Descriptor.cs
+++ b/Source/Plugin.BLE.iOS/Descriptor.cs
@@ -5,6 +5,7 @@ using Plugin.BLE.Abstractions;
 using Foundation;
 using Plugin.BLE.Abstractions.Contracts;
 using Plugin.BLE.Abstractions.Utils;
+using System.Threading;
 
 namespace Plugin.BLE.iOS
 {
@@ -47,7 +48,7 @@ namespace Plugin.BLE.iOS
             _nativeDescriptor = nativeDescriptor;
         }
 
-        protected override Task<byte[]> ReadNativeAsync()
+        protected override Task<byte[]> ReadNativeAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return TaskBuilder.FromEvent<byte[], EventHandler<CBDescriptorEventArgs>>(
                    execute: () => _parentDevice.ReadValue(_nativeDescriptor),
@@ -62,10 +63,11 @@ namespace Plugin.BLE.iOS
                            complete(Value);
                    },
                    subscribeComplete: handler => _parentDevice.UpdatedValue += handler,
-                   unsubscribeComplete: handler => _parentDevice.UpdatedValue -= handler);
+                   unsubscribeComplete: handler => _parentDevice.UpdatedValue -= handler,
+                   token: cancellationToken);
         }
 
-        protected override Task WriteNativeAsync(byte[] data)
+        protected override Task WriteNativeAsync(byte[] data, CancellationToken cancellationToken = default(CancellationToken))
         {
             return TaskBuilder.FromEvent<bool, EventHandler<CBDescriptorEventArgs>>(
                 execute: () => _parentDevice.WriteValue(NSData.FromArray(data), _nativeDescriptor),
@@ -80,7 +82,8 @@ namespace Plugin.BLE.iOS
                             complete(true);
                     },
                     subscribeComplete: handler => _parentDevice.WroteDescriptorValue += handler,
-                    unsubscribeComplete: handler => _parentDevice.WroteDescriptorValue -= handler);
+                    unsubscribeComplete: handler => _parentDevice.WroteDescriptorValue -= handler,
+                    token: cancellationToken);
         }
 
     }

--- a/Source/Plugin.BLE.iOS/Device.cs
+++ b/Source/Plugin.BLE.iOS/Device.cs
@@ -7,6 +7,7 @@ using Foundation;
 using Plugin.BLE.Abstractions;
 using Plugin.BLE.Abstractions.Contracts;
 using Plugin.BLE.Abstractions.Utils;
+using System.Threading;
 
 namespace Plugin.BLE.iOS
 {
@@ -42,7 +43,7 @@ namespace Plugin.BLE.iOS
             Trace.Message("Device changed name: {0}", Name);
         }
 
-        protected override Task<IEnumerable<IService>> GetServicesNativeAsync()
+        protected override Task<IEnumerable<IService>> GetServicesNativeAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return TaskBuilder.FromEvent<IEnumerable<IService>, EventHandler<NSErrorEventArgs>>(
                execute: () => _nativeDevice.DiscoverServices(),
@@ -67,7 +68,8 @@ namespace Plugin.BLE.iOS
                    }
                },
                subscribeComplete: handler => _nativeDevice.DiscoveredService += handler,
-               unsubscribeComplete: handler => _nativeDevice.DiscoveredService -= handler);
+               unsubscribeComplete: handler => _nativeDevice.DiscoveredService -= handler,
+               token: cancellationToken);
         }
 
         public override async Task<bool> UpdateRssiAsync()

--- a/Source/Plugin.BLE.iOS/Service.cs
+++ b/Source/Plugin.BLE.iOS/Service.cs
@@ -6,6 +6,7 @@ using CoreBluetooth;
 using Plugin.BLE.Abstractions;
 using Plugin.BLE.Abstractions.Contracts;
 using Plugin.BLE.Abstractions.Utils;
+using System.Threading;
 
 namespace Plugin.BLE.iOS
 {
@@ -23,7 +24,7 @@ namespace Plugin.BLE.iOS
             _device = device.NativeDevice as CBPeripheral;
         }
 
-        protected override Task<IList<ICharacteristic>> GetCharacteristicsNativeAsync()
+        protected override Task<IList<ICharacteristic>> GetCharacteristicsNativeAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return TaskBuilder.FromEvent<IList<ICharacteristic>, EventHandler<CBServiceEventArgs>>(
                 execute: () => _device.DiscoverCharacteristics(_service),
@@ -47,7 +48,8 @@ namespace Plugin.BLE.iOS
                     }
                 },
                 subscribeComplete: handler => _device.DiscoveredCharacteristic += handler,
-                unsubscribeComplete: handler => _device.DiscoveredCharacteristic -= handler);
+                unsubscribeComplete: handler => _device.DiscoveredCharacteristic -= handler,
+                token: cancellationToken);
         }
     }
 }


### PR DESCRIPTION
Issue #245 Fix: Added CancellationToken parameters to *NativeAsync methods.

Reason: peripheral:didWriteValueForCharacteristic:error: (CBPeripheral.WroteCharacteristicValue)
does not get called when connection is lost during a write (peripheral moved out of range, shut off without sending disconnect notification, etc.).  This results in the Task created in TaskBuilder.FromEvent never transitioning to Completed or Failed, causing the UI to hang indefinitely .  Thus, a timeout should be implemented in the application to trigger a cancellation.  However, previously, the CancellationToken passed into the *Async methods did not get passed through to the *NativeAsync methods, causing the cancellation to not end the Task and the Task to leak.

Issue discovered and fix tested on iOS 10.3.3