### PR TITLE
Fix #297 - Close created GATT when cancelling autoconnect requests

### DIFF
--- a/Source/Plugin.BLE.Android/Adapter.cs
+++ b/Source/Plugin.BLE.Android/Adapter.cs
@@ -143,7 +143,7 @@ namespace Plugin.BLE.Android
         protected override Task ConnectToDeviceNativeAsync(IDevice device, ConnectParameters connectParameters,
             CancellationToken cancellationToken)
         {
-            ((Device)device).Connect(connectParameters);
+            ((Device)device).Connect(connectParameters, cancellationToken);
             return Task.CompletedTask;
         }
 

--- a/Source/Plugin.BLE.Android/Device.cs
+++ b/Source/Plugin.BLE.Android/Device.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Android.App;
 using Android.OS;
@@ -77,30 +78,29 @@ namespace Plugin.BLE.Android
                 unsubscribeReject: handler => _gattCallback.ConnectionInterrupted -= handler);
         }
 
-        public void Connect(ConnectParameters connectParameters)
+        public void Connect(ConnectParameters connectParameters, CancellationToken cancellationToken)
         {
             IsOperationRequested = true;
             IsAutoConnectRequested = connectParameters.AutoConnect;
 
-            if (connectParameters.ForceBleTransport)
-            {
-                ConnectToGattForceBleTransportAPI(connectParameters.AutoConnect);
-            }
-            else
-            {
-                /*_gatt = */
-                BluetoothDevice.ConnectGatt(Application.Context, connectParameters.AutoConnect, _gattCallback);
+            var gatt = connectParameters.ForceBleTransport
+                ? ConnectToGattForceBleTransportAPI(connectParameters.AutoConnect)
+                : BluetoothDevice.ConnectGatt(Application.Context, connectParameters.AutoConnect, _gattCallback);
+
+            if (IsAutoConnectRequested)
+            {   // Close GATT to unregister device connection when connection request is canceled
+                cancellationToken.Register(() => gatt.Close());
             }
         }
 
-        private void ConnectToGattForceBleTransportAPI(bool autoconnect)
+        private BluetoothGatt ConnectToGattForceBleTransportAPI(bool autoconnect)
         {
             //This parameter is present from API 18 but only public from API 23
             //So reflection is used before API 23
             if (Build.VERSION.SdkInt < BuildVersionCodes.Lollipop)
             {
                 //no transport mode before lollipop, it will probably not work... gattCallBackError 133 again alas
-                BluetoothDevice.ConnectGatt(Application.Context, autoconnect, _gattCallback);
+                return BluetoothDevice.ConnectGatt(Application.Context, autoconnect, _gattCallback);
             }
             else if (Build.VERSION.SdkInt < BuildVersionCodes.M)
             {
@@ -111,13 +111,12 @@ namespace Plugin.BLE.Android
                                 Java.Lang.Integer.Type});
 
                 var transport = BluetoothDevice.Class.GetDeclaredField("TRANSPORT_LE").GetInt(null); // LE = 2, BREDR = 1, AUTO = 0
-                m.Invoke(BluetoothDevice, Application.Context, false, _gattCallback, transport);
+                return (BluetoothGatt)m.Invoke(BluetoothDevice, Application.Context, false, _gattCallback, transport);
             }
             else
             {
-                BluetoothDevice.ConnectGatt(Application.Context, autoconnect, _gattCallback, BluetoothTransports.Le);
+                return BluetoothDevice.ConnectGatt(Application.Context, autoconnect, _gattCallback, BluetoothTransports.Le);
             }
-
         }
 
         /// <summary>

--- a/Source/Plugin.BLE.Android/Device.cs
+++ b/Source/Plugin.BLE.Android/Device.cs
@@ -111,7 +111,7 @@ namespace Plugin.BLE.Android
                                 Java.Lang.Integer.Type});
 
                 var transport = BluetoothDevice.Class.GetDeclaredField("TRANSPORT_LE").GetInt(null); // LE = 2, BREDR = 1, AUTO = 0
-                return (BluetoothGatt)m.Invoke(BluetoothDevice, Application.Context, false, _gattCallback, transport);
+                return (BluetoothGatt)m.Invoke(BluetoothDevice, Application.Context, autoconnect, _gattCallback, transport);
             }
             else
             {


### PR DESCRIPTION
Application is registered for notifications when an autoconnected device comes into range. There is a maximum amount of registrations allowed simultaneously, and each connect creates a new registration:

```
I/mono-stdout(10118): $> Attempt connect (last attempt 4381ms ago)
D/BluetoothManager(10118): getConnectionState()
D/BluetoothManager(10118): getConnectedDevices
D/BtGatt.GattService( 1665): getDeviceType() - device=24:71:89:2B:3F:45, type=2
D/BluetoothGatt(10118): connect() - device: A0:E6:F8:88:C5:12, auto: true
D/BluetoothGatt(10118): registerApp()
D/BluetoothGatt(10118): registerApp() - UUID=dcc69ef2-65ae-4053-b909-a54da55a24f2
D/BtGatt.GattService( 1665): registerClient() - UUID=dcc69ef2-65ae-4053-b909-a54da55a24f2
D/BtGatt.GattService( 1665): onClientRegistered() - UUID=dcc69ef2-65ae-4053-b909-a54da55a24f2, clientIf=6
```

If the GATT is not closed after the connection attempt is canceled, this limit is reached and all subsequent connection attempts fail immediately:

```
04-23 21:10:23.998 29113 29266 E bt_att  : GATT_Register: can't Register GATT client, MAX client reached!
04-23 21:10:23.998 29113 29266 E bt_btif : Register with GATT stack failed.
04-23 21:10:23.998 29113 29266 E bt_att  : GATT_Register: can't Register GATT client, MAX client reached!
04-23 21:10:23.998 29113 29266 E bt_btif : Register with GATT stack failed.
```

Closing the GATT on cancellation frees up the connection slot for future connection attempts:
```
D/BluetoothGatt(10118): close()
D/BluetoothGatt(10118): unregisterApp() - mClientIf=6
D/BtGatt.GattService( 1665): unregisterClient() - clientIf=6
D/BtGatt.GattService( 1665): onDisconnected() - clientIf=6, connId=0, address=A0:E6:F8:88:C5:12
E/BtGatt.ContextMap( 1665): Context not found for ID 6
I/mono-stdout(10118): $> Attempt connect (last attempt 4381ms ago)
``` 