### PR TITLE
[iOS] Initial support for state restoration with CentralManagerDelegate

### DIFF
--- a/Source/Plugin.BLE.iOS/Adapter.cs
+++ b/Source/Plugin.BLE.iOS/Adapter.cs
@@ -15,13 +15,13 @@ namespace Plugin.BLE.iOS
     {
         private readonly AutoResetEvent _stateChanged = new AutoResetEvent(false);
         private readonly CBCentralManager _centralManager;
-	    private readonly IBleCentralManagerDelegate _bleCentralManagerDelegate;
+        private readonly IBleCentralManagerDelegate _bleCentralManagerDelegate;
 
-		/// <summary>
-		/// Registry used to store device instances for pending operations : disconnect
-		/// Helps to detect connection lost events.
-		/// </summary>
-		private readonly IDictionary<string, IDevice> _deviceOperationRegistry = new ConcurrentDictionary<string, IDevice>();
+        /// <summary>
+        /// Registry used to store device instances for pending operations : disconnect
+        /// Helps to detect connection lost events.
+        /// </summary>
+        private readonly IDictionary<string, IDevice> _deviceOperationRegistry = new ConcurrentDictionary<string, IDevice>();
         private readonly IDictionary<string, IDevice> _deviceConnectionRegistry = new ConcurrentDictionary<string, IDevice>();
 
         public override IList<IDevice> ConnectedDevices => _deviceConnectionRegistry.Values.ToList();
@@ -30,7 +30,7 @@ namespace Plugin.BLE.iOS
         public Adapter(CBCentralManager centralManager, IBleCentralManagerDelegate bleCentralManagerDelegate)
         {
             _centralManager = centralManager;
-	        _bleCentralManagerDelegate = bleCentralManagerDelegate;
+            _bleCentralManagerDelegate = bleCentralManagerDelegate;
 
             _bleCentralManagerDelegate.DiscoveredPeripheral += (sender, e) =>
             {

--- a/Source/Plugin.BLE.iOS/BleCentralManagerDelegate.cs
+++ b/Source/Plugin.BLE.iOS/BleCentralManagerDelegate.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using CoreBluetooth;
+using Foundation;
+
+namespace Plugin.BLE
+{
+	public interface IBleCentralManagerDelegate
+	{
+		event EventHandler<CBWillRestoreEventArgs> WillRestoreState;
+		event EventHandler<CBPeripheralsEventArgs> RetrievedPeripherals;
+		event EventHandler<CBPeripheralsEventArgs> RetrievedConnectedPeripherals;
+		event EventHandler<CBPeripheralErrorEventArgs> FailedToConnectPeripheral;
+		event EventHandler<CBDiscoveredPeripheralEventArgs> DiscoveredPeripheral;
+		event EventHandler<CBPeripheralErrorEventArgs> DisconnectedPeripheral;
+		event EventHandler UpdatedState;
+		event EventHandler<CBPeripheralEventArgs> ConnectedPeripheral;
+	}
+
+	public class BleBleCentralManagerDelegate : CBCentralManagerDelegate, IBleCentralManagerDelegate
+	{
+		#region IBleCentralManagerDelegate events
+
+		private event EventHandler<CBWillRestoreEventArgs> _willRestoreState;
+		event EventHandler<CBWillRestoreEventArgs> IBleCentralManagerDelegate.WillRestoreState
+		{
+			add => _willRestoreState += value;
+			remove => _willRestoreState -= value;
+		}
+
+		private event EventHandler<CBPeripheralsEventArgs> _retrievedPeripherals;
+		event EventHandler<CBPeripheralsEventArgs> IBleCentralManagerDelegate.RetrievedPeripherals
+		{
+			add => _retrievedPeripherals += value;
+			remove => _retrievedPeripherals -= value;
+		}
+
+		private event EventHandler<CBPeripheralsEventArgs> _retrievedConnectedPeripherals;
+		event EventHandler<CBPeripheralsEventArgs> IBleCentralManagerDelegate.RetrievedConnectedPeripherals
+		{
+			add => _retrievedConnectedPeripherals += value;
+			remove => _retrievedConnectedPeripherals -= value;
+		}
+
+		private event EventHandler<CBPeripheralErrorEventArgs> _failedToConnectPeripheral;
+		event EventHandler<CBPeripheralErrorEventArgs> IBleCentralManagerDelegate.FailedToConnectPeripheral
+		{
+			add => _failedToConnectPeripheral += value;
+			remove => _failedToConnectPeripheral -= value;
+		}
+
+		private event EventHandler<CBDiscoveredPeripheralEventArgs> _discoveredPeripheral;
+		event EventHandler<CBDiscoveredPeripheralEventArgs> IBleCentralManagerDelegate.DiscoveredPeripheral
+		{
+			add => _discoveredPeripheral += value;
+			remove => _discoveredPeripheral -= value;
+		}
+
+		private event EventHandler<CBPeripheralErrorEventArgs> _disconnectedPeripheral;
+		event EventHandler<CBPeripheralErrorEventArgs> IBleCentralManagerDelegate.DisconnectedPeripheral
+		{
+			add => _disconnectedPeripheral += value;
+			remove => _disconnectedPeripheral -= value;
+		}
+
+		private event EventHandler _updatedState;
+		event EventHandler IBleCentralManagerDelegate.UpdatedState
+		{
+			add => _updatedState += value;
+			remove => _updatedState -= value;
+		}
+
+		private event EventHandler<CBPeripheralEventArgs> _connectedPeripheral;
+		event EventHandler<CBPeripheralEventArgs> IBleCentralManagerDelegate.ConnectedPeripheral
+		{
+			add => _connectedPeripheral += value;
+			remove => _connectedPeripheral -= value;
+		}
+
+		#endregion
+
+		#region Event wiring
+
+		public override void WillRestoreState(CBCentralManager central, NSDictionary dict)
+		{
+			_willRestoreState?.Invoke(this, new CBWillRestoreEventArgs(dict));
+		}
+
+		public override void RetrievedPeripherals(CBCentralManager central, CBPeripheral[] peripherals)
+		{
+			_retrievedPeripherals?.Invoke(this, new CBPeripheralsEventArgs(peripherals));
+		}
+
+		public override void RetrievedConnectedPeripherals(CBCentralManager central, CBPeripheral[] peripherals)
+		{
+			_retrievedConnectedPeripherals?.Invoke(this, new CBPeripheralsEventArgs(peripherals));
+		}
+
+		public override void FailedToConnectPeripheral(CBCentralManager central, CBPeripheral peripheral, NSError error)
+		{
+			_failedToConnectPeripheral?.Invoke(this, new CBPeripheralErrorEventArgs(peripheral, error));
+		}
+
+		public override void DiscoveredPeripheral(CBCentralManager central, CBPeripheral peripheral, NSDictionary advertisementData, NSNumber RSSI)
+		{
+			_discoveredPeripheral?.Invoke(this, new CBDiscoveredPeripheralEventArgs(peripheral, advertisementData, RSSI));
+		}
+
+		public override void DisconnectedPeripheral(CBCentralManager central, CBPeripheral peripheral, NSError error)
+		{
+			_disconnectedPeripheral?.Invoke(this, new CBPeripheralErrorEventArgs(peripheral, error));
+		}
+
+		public override void UpdatedState(CBCentralManager central)
+		{
+			_updatedState?.Invoke(this, EventArgs.Empty);
+		}
+
+		public override void ConnectedPeripheral(CBCentralManager central, CBPeripheral peripheral)
+		{
+			_connectedPeripheral?.Invoke(this, new CBPeripheralEventArgs(peripheral));
+		}
+
+		#endregion
+	}
+}

--- a/Source/Plugin.BLE.iOS/BleCentralManagerDelegate.cs
+++ b/Source/Plugin.BLE.iOS/BleCentralManagerDelegate.cs
@@ -4,122 +4,132 @@ using Foundation;
 
 namespace Plugin.BLE
 {
-	public interface IBleCentralManagerDelegate
-	{
-		event EventHandler<CBWillRestoreEventArgs> WillRestoreState;
-		event EventHandler<CBPeripheralsEventArgs> RetrievedPeripherals;
-		event EventHandler<CBPeripheralsEventArgs> RetrievedConnectedPeripherals;
-		event EventHandler<CBPeripheralErrorEventArgs> FailedToConnectPeripheral;
-		event EventHandler<CBDiscoveredPeripheralEventArgs> DiscoveredPeripheral;
-		event EventHandler<CBPeripheralErrorEventArgs> DisconnectedPeripheral;
-		event EventHandler UpdatedState;
-		event EventHandler<CBPeripheralEventArgs> ConnectedPeripheral;
-	}
+    public interface IBleCentralManagerDelegate
+    {
+        event EventHandler<CBWillRestoreEventArgs> WillRestoreState;
+        event EventHandler<CBPeripheralsEventArgs> RetrievedPeripherals;
+        event EventHandler<CBPeripheralsEventArgs> RetrievedConnectedPeripherals;
+        event EventHandler<CBPeripheralErrorEventArgs> FailedToConnectPeripheral;
+        event EventHandler<CBDiscoveredPeripheralEventArgs> DiscoveredPeripheral;
+        event EventHandler<CBPeripheralErrorEventArgs> DisconnectedPeripheral;
+        event EventHandler UpdatedState;
+        event EventHandler<CBPeripheralEventArgs> ConnectedPeripheral;
+    }
 
-	public class BleBleCentralManagerDelegate : CBCentralManagerDelegate, IBleCentralManagerDelegate
-	{
-		#region IBleCentralManagerDelegate events
+    public class BleBleCentralManagerDelegate : CBCentralManagerDelegate, IBleCentralManagerDelegate
+    {
+        #region IBleCentralManagerDelegate events
 
-		private event EventHandler<CBWillRestoreEventArgs> _willRestoreState;
-		event EventHandler<CBWillRestoreEventArgs> IBleCentralManagerDelegate.WillRestoreState
-		{
-			add => _willRestoreState += value;
-			remove => _willRestoreState -= value;
-		}
+        private event EventHandler<CBWillRestoreEventArgs> _willRestoreState;
 
-		private event EventHandler<CBPeripheralsEventArgs> _retrievedPeripherals;
-		event EventHandler<CBPeripheralsEventArgs> IBleCentralManagerDelegate.RetrievedPeripherals
-		{
-			add => _retrievedPeripherals += value;
-			remove => _retrievedPeripherals -= value;
-		}
+        event EventHandler<CBWillRestoreEventArgs> IBleCentralManagerDelegate.WillRestoreState
+        {
+            add => _willRestoreState += value;
+            remove => _willRestoreState -= value;
+        }
 
-		private event EventHandler<CBPeripheralsEventArgs> _retrievedConnectedPeripherals;
-		event EventHandler<CBPeripheralsEventArgs> IBleCentralManagerDelegate.RetrievedConnectedPeripherals
-		{
-			add => _retrievedConnectedPeripherals += value;
-			remove => _retrievedConnectedPeripherals -= value;
-		}
+        private event EventHandler<CBPeripheralsEventArgs> _retrievedPeripherals;
 
-		private event EventHandler<CBPeripheralErrorEventArgs> _failedToConnectPeripheral;
-		event EventHandler<CBPeripheralErrorEventArgs> IBleCentralManagerDelegate.FailedToConnectPeripheral
-		{
-			add => _failedToConnectPeripheral += value;
-			remove => _failedToConnectPeripheral -= value;
-		}
+        event EventHandler<CBPeripheralsEventArgs> IBleCentralManagerDelegate.RetrievedPeripherals
+        {
+            add => _retrievedPeripherals += value;
+            remove => _retrievedPeripherals -= value;
+        }
 
-		private event EventHandler<CBDiscoveredPeripheralEventArgs> _discoveredPeripheral;
-		event EventHandler<CBDiscoveredPeripheralEventArgs> IBleCentralManagerDelegate.DiscoveredPeripheral
-		{
-			add => _discoveredPeripheral += value;
-			remove => _discoveredPeripheral -= value;
-		}
+        private event EventHandler<CBPeripheralsEventArgs> _retrievedConnectedPeripherals;
 
-		private event EventHandler<CBPeripheralErrorEventArgs> _disconnectedPeripheral;
-		event EventHandler<CBPeripheralErrorEventArgs> IBleCentralManagerDelegate.DisconnectedPeripheral
-		{
-			add => _disconnectedPeripheral += value;
-			remove => _disconnectedPeripheral -= value;
-		}
+        event EventHandler<CBPeripheralsEventArgs> IBleCentralManagerDelegate.RetrievedConnectedPeripherals
+        {
+            add => _retrievedConnectedPeripherals += value;
+            remove => _retrievedConnectedPeripherals -= value;
+        }
 
-		private event EventHandler _updatedState;
-		event EventHandler IBleCentralManagerDelegate.UpdatedState
-		{
-			add => _updatedState += value;
-			remove => _updatedState -= value;
-		}
+        private event EventHandler<CBPeripheralErrorEventArgs> _failedToConnectPeripheral;
 
-		private event EventHandler<CBPeripheralEventArgs> _connectedPeripheral;
-		event EventHandler<CBPeripheralEventArgs> IBleCentralManagerDelegate.ConnectedPeripheral
-		{
-			add => _connectedPeripheral += value;
-			remove => _connectedPeripheral -= value;
-		}
+        event EventHandler<CBPeripheralErrorEventArgs> IBleCentralManagerDelegate.FailedToConnectPeripheral
+        {
+            add => _failedToConnectPeripheral += value;
+            remove => _failedToConnectPeripheral -= value;
+        }
 
-		#endregion
+        private event EventHandler<CBDiscoveredPeripheralEventArgs> _discoveredPeripheral;
 
-		#region Event wiring
+        event EventHandler<CBDiscoveredPeripheralEventArgs> IBleCentralManagerDelegate.DiscoveredPeripheral
+        {
+            add => _discoveredPeripheral += value;
+            remove => _discoveredPeripheral -= value;
+        }
 
-		public override void WillRestoreState(CBCentralManager central, NSDictionary dict)
-		{
-			_willRestoreState?.Invoke(this, new CBWillRestoreEventArgs(dict));
-		}
+        private event EventHandler<CBPeripheralErrorEventArgs> _disconnectedPeripheral;
 
-		public override void RetrievedPeripherals(CBCentralManager central, CBPeripheral[] peripherals)
-		{
-			_retrievedPeripherals?.Invoke(this, new CBPeripheralsEventArgs(peripherals));
-		}
+        event EventHandler<CBPeripheralErrorEventArgs> IBleCentralManagerDelegate.DisconnectedPeripheral
+        {
+            add => _disconnectedPeripheral += value;
+            remove => _disconnectedPeripheral -= value;
+        }
 
-		public override void RetrievedConnectedPeripherals(CBCentralManager central, CBPeripheral[] peripherals)
-		{
-			_retrievedConnectedPeripherals?.Invoke(this, new CBPeripheralsEventArgs(peripherals));
-		}
+        private event EventHandler _updatedState;
 
-		public override void FailedToConnectPeripheral(CBCentralManager central, CBPeripheral peripheral, NSError error)
-		{
-			_failedToConnectPeripheral?.Invoke(this, new CBPeripheralErrorEventArgs(peripheral, error));
-		}
+        event EventHandler IBleCentralManagerDelegate.UpdatedState
+        {
+            add => _updatedState += value;
+            remove => _updatedState -= value;
+        }
 
-		public override void DiscoveredPeripheral(CBCentralManager central, CBPeripheral peripheral, NSDictionary advertisementData, NSNumber RSSI)
-		{
-			_discoveredPeripheral?.Invoke(this, new CBDiscoveredPeripheralEventArgs(peripheral, advertisementData, RSSI));
-		}
+        private event EventHandler<CBPeripheralEventArgs> _connectedPeripheral;
 
-		public override void DisconnectedPeripheral(CBCentralManager central, CBPeripheral peripheral, NSError error)
-		{
-			_disconnectedPeripheral?.Invoke(this, new CBPeripheralErrorEventArgs(peripheral, error));
-		}
+        event EventHandler<CBPeripheralEventArgs> IBleCentralManagerDelegate.ConnectedPeripheral
+        {
+            add => _connectedPeripheral += value;
+            remove => _connectedPeripheral -= value;
+        }
 
-		public override void UpdatedState(CBCentralManager central)
-		{
-			_updatedState?.Invoke(this, EventArgs.Empty);
-		}
+        #endregion
 
-		public override void ConnectedPeripheral(CBCentralManager central, CBPeripheral peripheral)
-		{
-			_connectedPeripheral?.Invoke(this, new CBPeripheralEventArgs(peripheral));
-		}
+        #region Event wiring
 
-		#endregion
-	}
+        public override void WillRestoreState(CBCentralManager central, NSDictionary dict)
+        {
+            _willRestoreState?.Invoke(this, new CBWillRestoreEventArgs(dict));
+        }
+
+        public override void RetrievedPeripherals(CBCentralManager central, CBPeripheral[] peripherals)
+        {
+            _retrievedPeripherals?.Invoke(this, new CBPeripheralsEventArgs(peripherals));
+        }
+
+        public override void RetrievedConnectedPeripherals(CBCentralManager central, CBPeripheral[] peripherals)
+        {
+            _retrievedConnectedPeripherals?.Invoke(this, new CBPeripheralsEventArgs(peripherals));
+        }
+
+        public override void FailedToConnectPeripheral(CBCentralManager central, CBPeripheral peripheral, NSError error)
+        {
+            _failedToConnectPeripheral?.Invoke(this, new CBPeripheralErrorEventArgs(peripheral, error));
+        }
+
+        public override void DiscoveredPeripheral(CBCentralManager central, CBPeripheral peripheral,
+            NSDictionary advertisementData, NSNumber RSSI)
+        {
+            _discoveredPeripheral?.Invoke(this,
+                new CBDiscoveredPeripheralEventArgs(peripheral, advertisementData, RSSI));
+        }
+
+        public override void DisconnectedPeripheral(CBCentralManager central, CBPeripheral peripheral, NSError error)
+        {
+            _disconnectedPeripheral?.Invoke(this, new CBPeripheralErrorEventArgs(peripheral, error));
+        }
+
+        public override void UpdatedState(CBCentralManager central)
+        {
+            _updatedState?.Invoke(this, EventArgs.Empty);
+        }
+
+        public override void ConnectedPeripheral(CBCentralManager central, CBPeripheral peripheral)
+        {
+            _connectedPeripheral?.Invoke(this, new CBPeripheralEventArgs(peripheral));
+        }
+
+        #endregion
+    }
 }

--- a/Source/Plugin.BLE.iOS/BleCentralManagerDelegate.cs
+++ b/Source/Plugin.BLE.iOS/BleCentralManagerDelegate.cs
@@ -16,7 +16,7 @@ namespace Plugin.BLE
         event EventHandler<CBPeripheralEventArgs> ConnectedPeripheral;
     }
 
-    public class BleBleCentralManagerDelegate : CBCentralManagerDelegate, IBleCentralManagerDelegate
+    public class BleCentralManagerDelegate : CBCentralManagerDelegate, IBleCentralManagerDelegate
     {
         #region IBleCentralManagerDelegate events
 

--- a/Source/Plugin.BLE.iOS/BleImplementation.cs
+++ b/Source/Plugin.BLE.iOS/BleImplementation.cs
@@ -14,7 +14,7 @@ namespace Plugin.BLE
 
         protected override void InitializeNative()
         {
-            var cmDelegate = new BleBleCentralManagerDelegate();
+            var cmDelegate = new BleCentralManagerDelegate();
             _bleCentralManagerDelegate = cmDelegate;
 
             _centralManager = new CBCentralManager(cmDelegate, DispatchQueue.CurrentQueue);

--- a/Source/Plugin.BLE.iOS/BleImplementation.cs
+++ b/Source/Plugin.BLE.iOS/BleImplementation.cs
@@ -10,11 +10,15 @@ namespace Plugin.BLE
     internal class BleImplementation : BleImplementationBase
     {
         private CBCentralManager _centralManager;
+	    private IBleCentralManagerDelegate _bleCentralManagerDelegate;
 
         protected override void InitializeNative()
         {
-            _centralManager = new CBCentralManager(DispatchQueue.CurrentQueue);
-            _centralManager.UpdatedState += (s, e) => State = GetState();
+			var cmDelegate = new BleBleCentralManagerDelegate();
+	        _bleCentralManagerDelegate = cmDelegate;
+
+            _centralManager = new CBCentralManager(cmDelegate, DispatchQueue.CurrentQueue);
+            _bleCentralManagerDelegate.UpdatedState += (s, e) => State = GetState();
         }
 
         protected override BluetoothState GetInitialStateNative()
@@ -24,7 +28,7 @@ namespace Plugin.BLE
 
         protected override IAdapter CreateNativeAdapter()
         {
-            return new Adapter(_centralManager);
+            return new Adapter(_centralManager, _bleCentralManagerDelegate);
         }
 
         private BluetoothState GetState()

--- a/Source/Plugin.BLE.iOS/BleImplementation.cs
+++ b/Source/Plugin.BLE.iOS/BleImplementation.cs
@@ -10,12 +10,12 @@ namespace Plugin.BLE
     internal class BleImplementation : BleImplementationBase
     {
         private CBCentralManager _centralManager;
-	    private IBleCentralManagerDelegate _bleCentralManagerDelegate;
+        private IBleCentralManagerDelegate _bleCentralManagerDelegate;
 
         protected override void InitializeNative()
         {
-			var cmDelegate = new BleBleCentralManagerDelegate();
-	        _bleCentralManagerDelegate = cmDelegate;
+            var cmDelegate = new BleBleCentralManagerDelegate();
+            _bleCentralManagerDelegate = cmDelegate;
 
             _centralManager = new CBCentralManager(cmDelegate, DispatchQueue.CurrentQueue);
             _bleCentralManagerDelegate.UpdatedState += (s, e) => State = GetState();

--- a/Source/Plugin.BLE.iOS/Plugin.BLE.iOS.csproj
+++ b/Source/Plugin.BLE.iOS/Plugin.BLE.iOS.csproj
@@ -46,6 +46,7 @@
     </Compile>
     <Compile Include="Adapter.cs" />
     <Compile Include="BleImplementation.cs" />
+    <Compile Include="BleCentralManagerDelegate.cs" />
     <Compile Include="Characteristic.cs" />
     <Compile Include="DefaultTrace.cs" />
     <Compile Include="Descriptor.cs" />


### PR DESCRIPTION
Use `CentralManagerDelegate` instead of `CentralManager` events for handling BLE events on iOS. This will allow overrides of the default `BleImplementation`, so you can pass a `RestorationIdentifier` to `CentralManager` and keep all pending connections alive after the app was terminated due to memory pressure.

`BleCentralManagerDelegate` maps all the method overrides to the same events from the `CentralManager` to minimize code changes.

Example of `BleImplementation` override to pass a `RestorationIdentifier`:
```
protected override void InitializeNative()
{
    var cmOptions = new CBCentralInitOptions { RestoreIdentifier = BluetoothStateName };
    var cmDelegate = new BleCentralManagerDelegate();
    CentralManager = new CBCentralManager(cmDelegate, DispatchQueue.CurrentQueue, cmOptions);

    _centralManagerDelegate = cmDelegate;
    _centralManagerDelegate.UpdatedState += (s, e) => State = GetState();
}
```

Details on the iOS requirements for state restoration can be found [here](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/CoreBluetoothBackgroundProcessingForIOSApps/PerformingTasksWhileYourAppIsInTheBackground.html#//apple_ref/doc/uid/TP40013257-CH7-SW10).