### PR TITLE
Fix collection was modified; enumeration operation may not execute bug

### DIFF
--- a/Source/Plugin.BLE.Abstractions/DeviceBase.cs
+++ b/Source/Plugin.BLE.Abstractions/DeviceBase.cs
@@ -67,7 +67,7 @@ namespace Plugin.BLE.Abstractions
         public async Task<IService> GetServiceAsync(Guid id, CancellationToken cancellationToken = default(CancellationToken))
         {
             var services = await GetServicesAsync(cancellationToken);
-            return services.FirstOrDefault(x => x.Id == id);
+            return services.ToList().FirstOrDefault(x => x.Id == id);
         }
 
         public async Task<int> RequestMtuAsync(int requestValue)


### PR DESCRIPTION

Fixes collection was modified bug

```List`1+Enumerator[T].MoveNextRare ()
System.InvalidOperationException: Collection was modified; enumeration operation may not execute.

System.Linq
Enumerable.TryGetFirst[TSource] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] predicate, System.Boolean& found)
System.Linq
Enumerable.FirstOrDefault[TSource] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] predicate)
Plugin.BLE.Abstractions
DeviceBase+<GetServiceAsync>d__28.MoveNext ()
System.Runtime.CompilerServices
TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task)
System.Runtime.CompilerServices
TaskAwaiter.HandleNonSuccessAndDebuggerNotification
```