### PR TITLE
Fix possible nullpoint exception

### DIFF
--- a/Source/Plugin.BLE.Abstractions/AdapterBase.cs
+++ b/Source/Plugin.BLE.Abstractions/AdapterBase.cs
@@ -180,7 +180,7 @@ namespace Plugin.BLE.Abstractions
 
         public void HandleDiscoveredDevice(IDevice device)
         {
-            if (!_currentScanDeviceFilter(device))
+            if (_currentScanDeviceFilter != null && !_currentScanDeviceFilter(device))
                 return;
 
             DeviceAdvertised(this, new DeviceEventArgs { Device = device });


### PR DESCRIPTION
_currentScanDeviceFilter is null, if the app starts over willRestoreState. 
If _currentScanDeviceFilter is null, than no filter is set and we can ignore it.