### PR TITLE
Suppressed a few warnings across the solution.

### DIFF
--- a/Source/BLE.Client/BLE.Client.Droid/BLE.Client.Droid.csproj
+++ b/Source/BLE.Client/BLE.Client.Droid/BLE.Client.Droid.csproj
@@ -127,7 +127,7 @@
       <Version>3.1.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.1.0.581479</Version>
+      <Version>4.2.0.709249</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/Source/BLE.Client/BLE.Client.Droid/Resources/Resource.Designer.cs
+++ b/Source/BLE.Client/BLE.Client.Droid/Resources/Resource.Designer.cs
@@ -6244,9 +6244,9 @@ namespace BLE.Client.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.listMode = global::BLE.Client.Droid.Resource.Id.listMode;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.list_item = global::BLE.Client.Droid.Resource.Id.list_item;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.main_appbar = global::BLE.Client.Droid.Resource.Id.main_appbar;
-			global::Xamarin.Forms.Platform.Android.Resource.Id.main_scrollview = global::BLE.Client.Droid.Resource.Id.main_scrollview;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.main_tablayout = global::BLE.Client.Droid.Resource.Id.main_tablayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.main_toolbar = global::BLE.Client.Droid.Resource.Id.main_toolbar;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.main_viewpager = global::BLE.Client.Droid.Resource.Id.main_viewpager;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.masked = global::BLE.Client.Droid.Resource.Id.masked;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.media_actions = global::BLE.Client.Droid.Resource.Id.media_actions;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.message = global::BLE.Client.Droid.Resource.Id.message;
@@ -6295,7 +6295,6 @@ namespace BLE.Client.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.select_dialog_listview = global::BLE.Client.Droid.Resource.Id.select_dialog_listview;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.selected = global::BLE.Client.Droid.Resource.Id.selected;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.shellcontent_appbar = global::BLE.Client.Droid.Resource.Id.shellcontent_appbar;
-			global::Xamarin.Forms.Platform.Android.Resource.Id.shellcontent_scrollview = global::BLE.Client.Droid.Resource.Id.shellcontent_scrollview;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.shellcontent_toolbar = global::BLE.Client.Droid.Resource.Id.shellcontent_toolbar;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.shortcut = global::BLE.Client.Droid.Resource.Id.shortcut;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.showCustom = global::BLE.Client.Droid.Resource.Id.showCustom;
@@ -6989,6 +6988,7 @@ namespace BLE.Client.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TextInputLayout_OutlinedBox_Dense = global::BLE.Client.Droid.Resource.Style.Widget_MaterialComponents_TextInputLayout_OutlinedBox_Dense;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Toolbar = global::BLE.Client.Droid.Resource.Style.Widget_MaterialComponents_Toolbar;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Support_CoordinatorLayout = global::BLE.Client.Droid.Resource.Style.Widget_Support_CoordinatorLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.collectionViewStyle = global::BLE.Client.Droid.Resource.Style.collectionViewStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ActionBar = global::BLE.Client.Droid.Resource.Styleable.ActionBar;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ActionBar_background = global::BLE.Client.Droid.Resource.Styleable.ActionBar_background;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ActionBar_backgroundSplit = global::BLE.Client.Droid.Resource.Styleable.ActionBar_backgroundSplit;
@@ -9847,686 +9847,686 @@ namespace BLE.Client.Droid
 		public partial class Dimension
 		{
 			
-			// aapt resource value: 0x7f08001a
-			public const int abc_action_bar_content_inset_material = 2131230746;
+			// aapt resource value: 0x7f09001a
+			public const int abc_action_bar_content_inset_material = 2131296282;
 			
-			// aapt resource value: 0x7f08001b
-			public const int abc_action_bar_content_inset_with_nav = 2131230747;
+			// aapt resource value: 0x7f09001b
+			public const int abc_action_bar_content_inset_with_nav = 2131296283;
 			
-			// aapt resource value: 0x7f080010
-			public const int abc_action_bar_default_height_material = 2131230736;
+			// aapt resource value: 0x7f090010
+			public const int abc_action_bar_default_height_material = 2131296272;
 			
-			// aapt resource value: 0x7f08001c
-			public const int abc_action_bar_default_padding_end_material = 2131230748;
+			// aapt resource value: 0x7f09001c
+			public const int abc_action_bar_default_padding_end_material = 2131296284;
 			
-			// aapt resource value: 0x7f08001d
-			public const int abc_action_bar_default_padding_start_material = 2131230749;
+			// aapt resource value: 0x7f09001d
+			public const int abc_action_bar_default_padding_start_material = 2131296285;
 			
-			// aapt resource value: 0x7f08001f
-			public const int abc_action_bar_elevation_material = 2131230751;
+			// aapt resource value: 0x7f09001f
+			public const int abc_action_bar_elevation_material = 2131296287;
 			
-			// aapt resource value: 0x7f080020
-			public const int abc_action_bar_icon_vertical_padding_material = 2131230752;
+			// aapt resource value: 0x7f090020
+			public const int abc_action_bar_icon_vertical_padding_material = 2131296288;
 			
-			// aapt resource value: 0x7f080021
-			public const int abc_action_bar_overflow_padding_end_material = 2131230753;
+			// aapt resource value: 0x7f090021
+			public const int abc_action_bar_overflow_padding_end_material = 2131296289;
 			
-			// aapt resource value: 0x7f080022
-			public const int abc_action_bar_overflow_padding_start_material = 2131230754;
+			// aapt resource value: 0x7f090022
+			public const int abc_action_bar_overflow_padding_start_material = 2131296290;
 			
-			// aapt resource value: 0x7f080023
-			public const int abc_action_bar_stacked_max_height = 2131230755;
+			// aapt resource value: 0x7f090023
+			public const int abc_action_bar_stacked_max_height = 2131296291;
 			
-			// aapt resource value: 0x7f080024
-			public const int abc_action_bar_stacked_tab_max_width = 2131230756;
+			// aapt resource value: 0x7f090024
+			public const int abc_action_bar_stacked_tab_max_width = 2131296292;
 			
-			// aapt resource value: 0x7f080025
-			public const int abc_action_bar_subtitle_bottom_margin_material = 2131230757;
+			// aapt resource value: 0x7f090025
+			public const int abc_action_bar_subtitle_bottom_margin_material = 2131296293;
 			
-			// aapt resource value: 0x7f080026
-			public const int abc_action_bar_subtitle_top_margin_material = 2131230758;
+			// aapt resource value: 0x7f090026
+			public const int abc_action_bar_subtitle_top_margin_material = 2131296294;
 			
-			// aapt resource value: 0x7f080027
-			public const int abc_action_button_min_height_material = 2131230759;
+			// aapt resource value: 0x7f090027
+			public const int abc_action_button_min_height_material = 2131296295;
 			
-			// aapt resource value: 0x7f080028
-			public const int abc_action_button_min_width_material = 2131230760;
+			// aapt resource value: 0x7f090028
+			public const int abc_action_button_min_width_material = 2131296296;
 			
-			// aapt resource value: 0x7f080029
-			public const int abc_action_button_min_width_overflow_material = 2131230761;
+			// aapt resource value: 0x7f090029
+			public const int abc_action_button_min_width_overflow_material = 2131296297;
 			
-			// aapt resource value: 0x7f08000f
-			public const int abc_alert_dialog_button_bar_height = 2131230735;
+			// aapt resource value: 0x7f09000f
+			public const int abc_alert_dialog_button_bar_height = 2131296271;
 			
-			// aapt resource value: 0x7f08002a
-			public const int abc_alert_dialog_button_dimen = 2131230762;
+			// aapt resource value: 0x7f09002a
+			public const int abc_alert_dialog_button_dimen = 2131296298;
 			
-			// aapt resource value: 0x7f08002b
-			public const int abc_button_inset_horizontal_material = 2131230763;
+			// aapt resource value: 0x7f09002b
+			public const int abc_button_inset_horizontal_material = 2131296299;
 			
-			// aapt resource value: 0x7f08002c
-			public const int abc_button_inset_vertical_material = 2131230764;
+			// aapt resource value: 0x7f09002c
+			public const int abc_button_inset_vertical_material = 2131296300;
 			
-			// aapt resource value: 0x7f08002d
-			public const int abc_button_padding_horizontal_material = 2131230765;
+			// aapt resource value: 0x7f09002d
+			public const int abc_button_padding_horizontal_material = 2131296301;
 			
-			// aapt resource value: 0x7f08002e
-			public const int abc_button_padding_vertical_material = 2131230766;
+			// aapt resource value: 0x7f09002e
+			public const int abc_button_padding_vertical_material = 2131296302;
 			
-			// aapt resource value: 0x7f08002f
-			public const int abc_cascading_menus_min_smallest_width = 2131230767;
+			// aapt resource value: 0x7f09002f
+			public const int abc_cascading_menus_min_smallest_width = 2131296303;
 			
-			// aapt resource value: 0x7f080013
-			public const int abc_config_prefDialogWidth = 2131230739;
+			// aapt resource value: 0x7f090013
+			public const int abc_config_prefDialogWidth = 2131296275;
 			
-			// aapt resource value: 0x7f080030
-			public const int abc_control_corner_material = 2131230768;
+			// aapt resource value: 0x7f090030
+			public const int abc_control_corner_material = 2131296304;
 			
-			// aapt resource value: 0x7f080031
-			public const int abc_control_inset_material = 2131230769;
+			// aapt resource value: 0x7f090031
+			public const int abc_control_inset_material = 2131296305;
 			
-			// aapt resource value: 0x7f080032
-			public const int abc_control_padding_material = 2131230770;
+			// aapt resource value: 0x7f090032
+			public const int abc_control_padding_material = 2131296306;
 			
-			// aapt resource value: 0x7f080033
-			public const int abc_dialog_corner_radius_material = 2131230771;
+			// aapt resource value: 0x7f090033
+			public const int abc_dialog_corner_radius_material = 2131296307;
 			
-			// aapt resource value: 0x7f080014
-			public const int abc_dialog_fixed_height_major = 2131230740;
+			// aapt resource value: 0x7f090014
+			public const int abc_dialog_fixed_height_major = 2131296276;
 			
-			// aapt resource value: 0x7f080015
-			public const int abc_dialog_fixed_height_minor = 2131230741;
+			// aapt resource value: 0x7f090015
+			public const int abc_dialog_fixed_height_minor = 2131296277;
 			
-			// aapt resource value: 0x7f080016
-			public const int abc_dialog_fixed_width_major = 2131230742;
+			// aapt resource value: 0x7f090016
+			public const int abc_dialog_fixed_width_major = 2131296278;
 			
-			// aapt resource value: 0x7f080017
-			public const int abc_dialog_fixed_width_minor = 2131230743;
+			// aapt resource value: 0x7f090017
+			public const int abc_dialog_fixed_width_minor = 2131296279;
 			
-			// aapt resource value: 0x7f080034
-			public const int abc_dialog_list_padding_bottom_no_buttons = 2131230772;
+			// aapt resource value: 0x7f090034
+			public const int abc_dialog_list_padding_bottom_no_buttons = 2131296308;
 			
-			// aapt resource value: 0x7f080035
-			public const int abc_dialog_list_padding_top_no_title = 2131230773;
+			// aapt resource value: 0x7f090035
+			public const int abc_dialog_list_padding_top_no_title = 2131296309;
 			
-			// aapt resource value: 0x7f080018
-			public const int abc_dialog_min_width_major = 2131230744;
+			// aapt resource value: 0x7f090018
+			public const int abc_dialog_min_width_major = 2131296280;
 			
-			// aapt resource value: 0x7f080019
-			public const int abc_dialog_min_width_minor = 2131230745;
+			// aapt resource value: 0x7f090019
+			public const int abc_dialog_min_width_minor = 2131296281;
 			
-			// aapt resource value: 0x7f080036
-			public const int abc_dialog_padding_material = 2131230774;
+			// aapt resource value: 0x7f090036
+			public const int abc_dialog_padding_material = 2131296310;
 			
-			// aapt resource value: 0x7f080037
-			public const int abc_dialog_padding_top_material = 2131230775;
+			// aapt resource value: 0x7f090037
+			public const int abc_dialog_padding_top_material = 2131296311;
 			
-			// aapt resource value: 0x7f080038
-			public const int abc_dialog_title_divider_material = 2131230776;
+			// aapt resource value: 0x7f090038
+			public const int abc_dialog_title_divider_material = 2131296312;
 			
-			// aapt resource value: 0x7f080039
-			public const int abc_disabled_alpha_material_dark = 2131230777;
+			// aapt resource value: 0x7f090039
+			public const int abc_disabled_alpha_material_dark = 2131296313;
 			
-			// aapt resource value: 0x7f08003a
-			public const int abc_disabled_alpha_material_light = 2131230778;
+			// aapt resource value: 0x7f09003a
+			public const int abc_disabled_alpha_material_light = 2131296314;
 			
-			// aapt resource value: 0x7f08003b
-			public const int abc_dropdownitem_icon_width = 2131230779;
+			// aapt resource value: 0x7f09003b
+			public const int abc_dropdownitem_icon_width = 2131296315;
 			
-			// aapt resource value: 0x7f08003c
-			public const int abc_dropdownitem_text_padding_left = 2131230780;
+			// aapt resource value: 0x7f09003c
+			public const int abc_dropdownitem_text_padding_left = 2131296316;
 			
-			// aapt resource value: 0x7f08003d
-			public const int abc_dropdownitem_text_padding_right = 2131230781;
+			// aapt resource value: 0x7f09003d
+			public const int abc_dropdownitem_text_padding_right = 2131296317;
 			
-			// aapt resource value: 0x7f08003e
-			public const int abc_edit_text_inset_bottom_material = 2131230782;
+			// aapt resource value: 0x7f09003e
+			public const int abc_edit_text_inset_bottom_material = 2131296318;
 			
-			// aapt resource value: 0x7f08003f
-			public const int abc_edit_text_inset_horizontal_material = 2131230783;
+			// aapt resource value: 0x7f09003f
+			public const int abc_edit_text_inset_horizontal_material = 2131296319;
 			
-			// aapt resource value: 0x7f080040
-			public const int abc_edit_text_inset_top_material = 2131230784;
+			// aapt resource value: 0x7f090040
+			public const int abc_edit_text_inset_top_material = 2131296320;
 			
-			// aapt resource value: 0x7f080041
-			public const int abc_floating_window_z = 2131230785;
+			// aapt resource value: 0x7f090041
+			public const int abc_floating_window_z = 2131296321;
 			
-			// aapt resource value: 0x7f080042
-			public const int abc_list_item_padding_horizontal_material = 2131230786;
+			// aapt resource value: 0x7f090042
+			public const int abc_list_item_padding_horizontal_material = 2131296322;
 			
-			// aapt resource value: 0x7f080043
-			public const int abc_panel_menu_list_width = 2131230787;
+			// aapt resource value: 0x7f090043
+			public const int abc_panel_menu_list_width = 2131296323;
 			
-			// aapt resource value: 0x7f080044
-			public const int abc_progress_bar_height_material = 2131230788;
+			// aapt resource value: 0x7f090044
+			public const int abc_progress_bar_height_material = 2131296324;
 			
-			// aapt resource value: 0x7f080045
-			public const int abc_search_view_preferred_height = 2131230789;
+			// aapt resource value: 0x7f090045
+			public const int abc_search_view_preferred_height = 2131296325;
 			
-			// aapt resource value: 0x7f080046
-			public const int abc_search_view_preferred_width = 2131230790;
+			// aapt resource value: 0x7f090046
+			public const int abc_search_view_preferred_width = 2131296326;
 			
-			// aapt resource value: 0x7f080047
-			public const int abc_seekbar_track_background_height_material = 2131230791;
+			// aapt resource value: 0x7f090047
+			public const int abc_seekbar_track_background_height_material = 2131296327;
 			
-			// aapt resource value: 0x7f080048
-			public const int abc_seekbar_track_progress_height_material = 2131230792;
+			// aapt resource value: 0x7f090048
+			public const int abc_seekbar_track_progress_height_material = 2131296328;
 			
-			// aapt resource value: 0x7f080049
-			public const int abc_select_dialog_padding_start_material = 2131230793;
+			// aapt resource value: 0x7f090049
+			public const int abc_select_dialog_padding_start_material = 2131296329;
 			
-			// aapt resource value: 0x7f08001e
-			public const int abc_switch_padding = 2131230750;
+			// aapt resource value: 0x7f09001e
+			public const int abc_switch_padding = 2131296286;
 			
-			// aapt resource value: 0x7f08004a
-			public const int abc_text_size_body_1_material = 2131230794;
+			// aapt resource value: 0x7f09004a
+			public const int abc_text_size_body_1_material = 2131296330;
 			
-			// aapt resource value: 0x7f08004b
-			public const int abc_text_size_body_2_material = 2131230795;
+			// aapt resource value: 0x7f09004b
+			public const int abc_text_size_body_2_material = 2131296331;
 			
-			// aapt resource value: 0x7f08004c
-			public const int abc_text_size_button_material = 2131230796;
+			// aapt resource value: 0x7f09004c
+			public const int abc_text_size_button_material = 2131296332;
 			
-			// aapt resource value: 0x7f08004d
-			public const int abc_text_size_caption_material = 2131230797;
+			// aapt resource value: 0x7f09004d
+			public const int abc_text_size_caption_material = 2131296333;
 			
-			// aapt resource value: 0x7f08004e
-			public const int abc_text_size_display_1_material = 2131230798;
+			// aapt resource value: 0x7f09004e
+			public const int abc_text_size_display_1_material = 2131296334;
 			
-			// aapt resource value: 0x7f08004f
-			public const int abc_text_size_display_2_material = 2131230799;
+			// aapt resource value: 0x7f09004f
+			public const int abc_text_size_display_2_material = 2131296335;
 			
-			// aapt resource value: 0x7f080050
-			public const int abc_text_size_display_3_material = 2131230800;
+			// aapt resource value: 0x7f090050
+			public const int abc_text_size_display_3_material = 2131296336;
 			
-			// aapt resource value: 0x7f080051
-			public const int abc_text_size_display_4_material = 2131230801;
+			// aapt resource value: 0x7f090051
+			public const int abc_text_size_display_4_material = 2131296337;
 			
-			// aapt resource value: 0x7f080052
-			public const int abc_text_size_headline_material = 2131230802;
+			// aapt resource value: 0x7f090052
+			public const int abc_text_size_headline_material = 2131296338;
 			
-			// aapt resource value: 0x7f080053
-			public const int abc_text_size_large_material = 2131230803;
+			// aapt resource value: 0x7f090053
+			public const int abc_text_size_large_material = 2131296339;
 			
-			// aapt resource value: 0x7f080054
-			public const int abc_text_size_medium_material = 2131230804;
+			// aapt resource value: 0x7f090054
+			public const int abc_text_size_medium_material = 2131296340;
 			
-			// aapt resource value: 0x7f080055
-			public const int abc_text_size_menu_header_material = 2131230805;
+			// aapt resource value: 0x7f090055
+			public const int abc_text_size_menu_header_material = 2131296341;
 			
-			// aapt resource value: 0x7f080056
-			public const int abc_text_size_menu_material = 2131230806;
+			// aapt resource value: 0x7f090056
+			public const int abc_text_size_menu_material = 2131296342;
 			
-			// aapt resource value: 0x7f080057
-			public const int abc_text_size_small_material = 2131230807;
+			// aapt resource value: 0x7f090057
+			public const int abc_text_size_small_material = 2131296343;
 			
-			// aapt resource value: 0x7f080058
-			public const int abc_text_size_subhead_material = 2131230808;
+			// aapt resource value: 0x7f090058
+			public const int abc_text_size_subhead_material = 2131296344;
 			
-			// aapt resource value: 0x7f080011
-			public const int abc_text_size_subtitle_material_toolbar = 2131230737;
+			// aapt resource value: 0x7f090011
+			public const int abc_text_size_subtitle_material_toolbar = 2131296273;
 			
-			// aapt resource value: 0x7f080059
-			public const int abc_text_size_title_material = 2131230809;
+			// aapt resource value: 0x7f090059
+			public const int abc_text_size_title_material = 2131296345;
 			
-			// aapt resource value: 0x7f080012
-			public const int abc_text_size_title_material_toolbar = 2131230738;
+			// aapt resource value: 0x7f090012
+			public const int abc_text_size_title_material_toolbar = 2131296274;
 			
-			// aapt resource value: 0x7f0800cb
-			public const int browser_actions_context_menu_max_width = 2131230923;
+			// aapt resource value: 0x7f0900cb
+			public const int browser_actions_context_menu_max_width = 2131296459;
 			
-			// aapt resource value: 0x7f0800cc
-			public const int browser_actions_context_menu_min_padding = 2131230924;
+			// aapt resource value: 0x7f0900cc
+			public const int browser_actions_context_menu_min_padding = 2131296460;
 			
-			// aapt resource value: 0x7f08000c
-			public const int cardview_compat_inset_shadow = 2131230732;
+			// aapt resource value: 0x7f09000c
+			public const int cardview_compat_inset_shadow = 2131296268;
 			
-			// aapt resource value: 0x7f08000d
-			public const int cardview_default_elevation = 2131230733;
+			// aapt resource value: 0x7f09000d
+			public const int cardview_default_elevation = 2131296269;
 			
-			// aapt resource value: 0x7f08000e
-			public const int cardview_default_radius = 2131230734;
+			// aapt resource value: 0x7f09000e
+			public const int cardview_default_radius = 2131296270;
 			
-			// aapt resource value: 0x7f0800d1
-			public const int compat_button_inset_horizontal_material = 2131230929;
+			// aapt resource value: 0x7f0900d1
+			public const int compat_button_inset_horizontal_material = 2131296465;
 			
-			// aapt resource value: 0x7f0800d2
-			public const int compat_button_inset_vertical_material = 2131230930;
+			// aapt resource value: 0x7f0900d2
+			public const int compat_button_inset_vertical_material = 2131296466;
 			
-			// aapt resource value: 0x7f0800d3
-			public const int compat_button_padding_horizontal_material = 2131230931;
+			// aapt resource value: 0x7f0900d3
+			public const int compat_button_padding_horizontal_material = 2131296467;
 			
-			// aapt resource value: 0x7f0800d4
-			public const int compat_button_padding_vertical_material = 2131230932;
+			// aapt resource value: 0x7f0900d4
+			public const int compat_button_padding_vertical_material = 2131296468;
 			
-			// aapt resource value: 0x7f0800d5
-			public const int compat_control_corner_material = 2131230933;
+			// aapt resource value: 0x7f0900d5
+			public const int compat_control_corner_material = 2131296469;
 			
-			// aapt resource value: 0x7f0800d6
-			public const int compat_notification_large_icon_max_height = 2131230934;
+			// aapt resource value: 0x7f0900d6
+			public const int compat_notification_large_icon_max_height = 2131296470;
 			
-			// aapt resource value: 0x7f0800d7
-			public const int compat_notification_large_icon_max_width = 2131230935;
+			// aapt resource value: 0x7f0900d7
+			public const int compat_notification_large_icon_max_width = 2131296471;
 			
-			// aapt resource value: 0x7f080077
-			public const int design_appbar_elevation = 2131230839;
+			// aapt resource value: 0x7f090077
+			public const int design_appbar_elevation = 2131296375;
 			
-			// aapt resource value: 0x7f080078
-			public const int design_bottom_navigation_active_item_max_width = 2131230840;
+			// aapt resource value: 0x7f090078
+			public const int design_bottom_navigation_active_item_max_width = 2131296376;
 			
-			// aapt resource value: 0x7f080079
-			public const int design_bottom_navigation_active_item_min_width = 2131230841;
+			// aapt resource value: 0x7f090079
+			public const int design_bottom_navigation_active_item_min_width = 2131296377;
 			
-			// aapt resource value: 0x7f08007a
-			public const int design_bottom_navigation_active_text_size = 2131230842;
+			// aapt resource value: 0x7f09007a
+			public const int design_bottom_navigation_active_text_size = 2131296378;
 			
-			// aapt resource value: 0x7f08007b
-			public const int design_bottom_navigation_elevation = 2131230843;
+			// aapt resource value: 0x7f09007b
+			public const int design_bottom_navigation_elevation = 2131296379;
 			
-			// aapt resource value: 0x7f08007c
-			public const int design_bottom_navigation_height = 2131230844;
+			// aapt resource value: 0x7f09007c
+			public const int design_bottom_navigation_height = 2131296380;
 			
-			// aapt resource value: 0x7f08007d
-			public const int design_bottom_navigation_icon_size = 2131230845;
+			// aapt resource value: 0x7f09007d
+			public const int design_bottom_navigation_icon_size = 2131296381;
 			
-			// aapt resource value: 0x7f08007e
-			public const int design_bottom_navigation_item_max_width = 2131230846;
+			// aapt resource value: 0x7f09007e
+			public const int design_bottom_navigation_item_max_width = 2131296382;
 			
-			// aapt resource value: 0x7f08007f
-			public const int design_bottom_navigation_item_min_width = 2131230847;
+			// aapt resource value: 0x7f09007f
+			public const int design_bottom_navigation_item_min_width = 2131296383;
 			
-			// aapt resource value: 0x7f080080
-			public const int design_bottom_navigation_margin = 2131230848;
+			// aapt resource value: 0x7f090080
+			public const int design_bottom_navigation_margin = 2131296384;
 			
-			// aapt resource value: 0x7f080081
-			public const int design_bottom_navigation_shadow_height = 2131230849;
+			// aapt resource value: 0x7f090081
+			public const int design_bottom_navigation_shadow_height = 2131296385;
 			
-			// aapt resource value: 0x7f080082
-			public const int design_bottom_navigation_text_size = 2131230850;
+			// aapt resource value: 0x7f090082
+			public const int design_bottom_navigation_text_size = 2131296386;
 			
-			// aapt resource value: 0x7f080083
-			public const int design_bottom_sheet_modal_elevation = 2131230851;
+			// aapt resource value: 0x7f090083
+			public const int design_bottom_sheet_modal_elevation = 2131296387;
 			
-			// aapt resource value: 0x7f080084
-			public const int design_bottom_sheet_peek_height_min = 2131230852;
+			// aapt resource value: 0x7f090084
+			public const int design_bottom_sheet_peek_height_min = 2131296388;
 			
-			// aapt resource value: 0x7f080085
-			public const int design_fab_border_width = 2131230853;
+			// aapt resource value: 0x7f090085
+			public const int design_fab_border_width = 2131296389;
 			
-			// aapt resource value: 0x7f080086
-			public const int design_fab_elevation = 2131230854;
+			// aapt resource value: 0x7f090086
+			public const int design_fab_elevation = 2131296390;
 			
-			// aapt resource value: 0x7f080087
-			public const int design_fab_image_size = 2131230855;
+			// aapt resource value: 0x7f090087
+			public const int design_fab_image_size = 2131296391;
 			
-			// aapt resource value: 0x7f080088
-			public const int design_fab_size_mini = 2131230856;
+			// aapt resource value: 0x7f090088
+			public const int design_fab_size_mini = 2131296392;
 			
-			// aapt resource value: 0x7f080089
-			public const int design_fab_size_normal = 2131230857;
+			// aapt resource value: 0x7f090089
+			public const int design_fab_size_normal = 2131296393;
 			
-			// aapt resource value: 0x7f08008a
-			public const int design_fab_translation_z_hovered_focused = 2131230858;
+			// aapt resource value: 0x7f09008a
+			public const int design_fab_translation_z_hovered_focused = 2131296394;
 			
-			// aapt resource value: 0x7f08008b
-			public const int design_fab_translation_z_pressed = 2131230859;
+			// aapt resource value: 0x7f09008b
+			public const int design_fab_translation_z_pressed = 2131296395;
 			
-			// aapt resource value: 0x7f08008c
-			public const int design_navigation_elevation = 2131230860;
+			// aapt resource value: 0x7f09008c
+			public const int design_navigation_elevation = 2131296396;
 			
-			// aapt resource value: 0x7f08008d
-			public const int design_navigation_icon_padding = 2131230861;
+			// aapt resource value: 0x7f09008d
+			public const int design_navigation_icon_padding = 2131296397;
 			
-			// aapt resource value: 0x7f08008e
-			public const int design_navigation_icon_size = 2131230862;
+			// aapt resource value: 0x7f09008e
+			public const int design_navigation_icon_size = 2131296398;
 			
-			// aapt resource value: 0x7f08008f
-			public const int design_navigation_item_horizontal_padding = 2131230863;
+			// aapt resource value: 0x7f09008f
+			public const int design_navigation_item_horizontal_padding = 2131296399;
 			
-			// aapt resource value: 0x7f080090
-			public const int design_navigation_item_icon_padding = 2131230864;
+			// aapt resource value: 0x7f090090
+			public const int design_navigation_item_icon_padding = 2131296400;
 			
-			// aapt resource value: 0x7f08006f
-			public const int design_navigation_max_width = 2131230831;
+			// aapt resource value: 0x7f09006f
+			public const int design_navigation_max_width = 2131296367;
 			
-			// aapt resource value: 0x7f080091
-			public const int design_navigation_padding_bottom = 2131230865;
+			// aapt resource value: 0x7f090091
+			public const int design_navigation_padding_bottom = 2131296401;
 			
-			// aapt resource value: 0x7f080092
-			public const int design_navigation_separator_vertical_padding = 2131230866;
+			// aapt resource value: 0x7f090092
+			public const int design_navigation_separator_vertical_padding = 2131296402;
 			
-			// aapt resource value: 0x7f080070
-			public const int design_snackbar_action_inline_max_width = 2131230832;
+			// aapt resource value: 0x7f090070
+			public const int design_snackbar_action_inline_max_width = 2131296368;
 			
-			// aapt resource value: 0x7f080071
-			public const int design_snackbar_background_corner_radius = 2131230833;
+			// aapt resource value: 0x7f090071
+			public const int design_snackbar_background_corner_radius = 2131296369;
 			
-			// aapt resource value: 0x7f080093
-			public const int design_snackbar_elevation = 2131230867;
+			// aapt resource value: 0x7f090093
+			public const int design_snackbar_elevation = 2131296403;
 			
-			// aapt resource value: 0x7f080072
-			public const int design_snackbar_extra_spacing_horizontal = 2131230834;
+			// aapt resource value: 0x7f090072
+			public const int design_snackbar_extra_spacing_horizontal = 2131296370;
 			
-			// aapt resource value: 0x7f080073
-			public const int design_snackbar_max_width = 2131230835;
+			// aapt resource value: 0x7f090073
+			public const int design_snackbar_max_width = 2131296371;
 			
-			// aapt resource value: 0x7f080074
-			public const int design_snackbar_min_width = 2131230836;
+			// aapt resource value: 0x7f090074
+			public const int design_snackbar_min_width = 2131296372;
 			
-			// aapt resource value: 0x7f080094
-			public const int design_snackbar_padding_horizontal = 2131230868;
+			// aapt resource value: 0x7f090094
+			public const int design_snackbar_padding_horizontal = 2131296404;
 			
-			// aapt resource value: 0x7f080095
-			public const int design_snackbar_padding_vertical = 2131230869;
+			// aapt resource value: 0x7f090095
+			public const int design_snackbar_padding_vertical = 2131296405;
 			
-			// aapt resource value: 0x7f080075
-			public const int design_snackbar_padding_vertical_2lines = 2131230837;
+			// aapt resource value: 0x7f090075
+			public const int design_snackbar_padding_vertical_2lines = 2131296373;
 			
-			// aapt resource value: 0x7f080096
-			public const int design_snackbar_text_size = 2131230870;
+			// aapt resource value: 0x7f090096
+			public const int design_snackbar_text_size = 2131296406;
 			
-			// aapt resource value: 0x7f080097
-			public const int design_tab_max_width = 2131230871;
+			// aapt resource value: 0x7f090097
+			public const int design_tab_max_width = 2131296407;
 			
-			// aapt resource value: 0x7f080076
-			public const int design_tab_scrollable_min_width = 2131230838;
+			// aapt resource value: 0x7f090076
+			public const int design_tab_scrollable_min_width = 2131296374;
 			
-			// aapt resource value: 0x7f080098
-			public const int design_tab_text_size = 2131230872;
+			// aapt resource value: 0x7f090098
+			public const int design_tab_text_size = 2131296408;
 			
-			// aapt resource value: 0x7f080099
-			public const int design_tab_text_size_2line = 2131230873;
+			// aapt resource value: 0x7f090099
+			public const int design_tab_text_size_2line = 2131296409;
 			
-			// aapt resource value: 0x7f08009a
-			public const int design_textinput_caption_translate_y = 2131230874;
+			// aapt resource value: 0x7f09009a
+			public const int design_textinput_caption_translate_y = 2131296410;
 			
-			// aapt resource value: 0x7f08005a
-			public const int disabled_alpha_material_dark = 2131230810;
+			// aapt resource value: 0x7f09005a
+			public const int disabled_alpha_material_dark = 2131296346;
 			
-			// aapt resource value: 0x7f08005b
-			public const int disabled_alpha_material_light = 2131230811;
+			// aapt resource value: 0x7f09005b
+			public const int disabled_alpha_material_light = 2131296347;
 			
-			// aapt resource value: 0x7f080000
-			public const int fastscroll_default_thickness = 2131230720;
+			// aapt resource value: 0x7f090000
+			public const int fastscroll_default_thickness = 2131296256;
 			
-			// aapt resource value: 0x7f080001
-			public const int fastscroll_margin = 2131230721;
+			// aapt resource value: 0x7f090001
+			public const int fastscroll_margin = 2131296257;
 			
-			// aapt resource value: 0x7f080002
-			public const int fastscroll_minimum_range = 2131230722;
+			// aapt resource value: 0x7f090002
+			public const int fastscroll_minimum_range = 2131296258;
 			
-			// aapt resource value: 0x7f08005c
-			public const int highlight_alpha_material_colored = 2131230812;
+			// aapt resource value: 0x7f09005c
+			public const int highlight_alpha_material_colored = 2131296348;
 			
-			// aapt resource value: 0x7f08005d
-			public const int highlight_alpha_material_dark = 2131230813;
+			// aapt resource value: 0x7f09005d
+			public const int highlight_alpha_material_dark = 2131296349;
 			
-			// aapt resource value: 0x7f08005e
-			public const int highlight_alpha_material_light = 2131230814;
+			// aapt resource value: 0x7f09005e
+			public const int highlight_alpha_material_light = 2131296350;
 			
-			// aapt resource value: 0x7f08005f
-			public const int hint_alpha_material_dark = 2131230815;
+			// aapt resource value: 0x7f09005f
+			public const int hint_alpha_material_dark = 2131296351;
 			
-			// aapt resource value: 0x7f080060
-			public const int hint_alpha_material_light = 2131230816;
+			// aapt resource value: 0x7f090060
+			public const int hint_alpha_material_light = 2131296352;
 			
-			// aapt resource value: 0x7f080061
-			public const int hint_pressed_alpha_material_dark = 2131230817;
+			// aapt resource value: 0x7f090061
+			public const int hint_pressed_alpha_material_dark = 2131296353;
 			
-			// aapt resource value: 0x7f080062
-			public const int hint_pressed_alpha_material_light = 2131230818;
+			// aapt resource value: 0x7f090062
+			public const int hint_pressed_alpha_material_light = 2131296354;
 			
-			// aapt resource value: 0x7f080003
-			public const int item_touch_helper_max_drag_scroll_per_frame = 2131230723;
+			// aapt resource value: 0x7f090003
+			public const int item_touch_helper_max_drag_scroll_per_frame = 2131296259;
 			
-			// aapt resource value: 0x7f080004
-			public const int item_touch_helper_swipe_escape_max_velocity = 2131230724;
+			// aapt resource value: 0x7f090004
+			public const int item_touch_helper_swipe_escape_max_velocity = 2131296260;
 			
-			// aapt resource value: 0x7f080005
-			public const int item_touch_helper_swipe_escape_velocity = 2131230725;
+			// aapt resource value: 0x7f090005
+			public const int item_touch_helper_swipe_escape_velocity = 2131296261;
 			
-			// aapt resource value: 0x7f080006
-			public const int mr_controller_volume_group_list_item_height = 2131230726;
+			// aapt resource value: 0x7f090006
+			public const int mr_controller_volume_group_list_item_height = 2131296262;
 			
-			// aapt resource value: 0x7f080007
-			public const int mr_controller_volume_group_list_item_icon_size = 2131230727;
+			// aapt resource value: 0x7f090007
+			public const int mr_controller_volume_group_list_item_icon_size = 2131296263;
 			
-			// aapt resource value: 0x7f080008
-			public const int mr_controller_volume_group_list_max_height = 2131230728;
+			// aapt resource value: 0x7f090008
+			public const int mr_controller_volume_group_list_max_height = 2131296264;
 			
-			// aapt resource value: 0x7f08000b
-			public const int mr_controller_volume_group_list_padding_top = 2131230731;
+			// aapt resource value: 0x7f09000b
+			public const int mr_controller_volume_group_list_padding_top = 2131296267;
 			
-			// aapt resource value: 0x7f080009
-			public const int mr_dialog_fixed_width_major = 2131230729;
+			// aapt resource value: 0x7f090009
+			public const int mr_dialog_fixed_width_major = 2131296265;
 			
-			// aapt resource value: 0x7f08000a
-			public const int mr_dialog_fixed_width_minor = 2131230730;
+			// aapt resource value: 0x7f09000a
+			public const int mr_dialog_fixed_width_minor = 2131296266;
 			
-			// aapt resource value: 0x7f08009b
-			public const int mtrl_bottomappbar_fabOffsetEndMode = 2131230875;
+			// aapt resource value: 0x7f09009b
+			public const int mtrl_bottomappbar_fabOffsetEndMode = 2131296411;
 			
-			// aapt resource value: 0x7f08009c
-			public const int mtrl_bottomappbar_fab_cradle_margin = 2131230876;
+			// aapt resource value: 0x7f09009c
+			public const int mtrl_bottomappbar_fab_cradle_margin = 2131296412;
 			
-			// aapt resource value: 0x7f08009d
-			public const int mtrl_bottomappbar_fab_cradle_rounded_corner_radius = 2131230877;
+			// aapt resource value: 0x7f09009d
+			public const int mtrl_bottomappbar_fab_cradle_rounded_corner_radius = 2131296413;
 			
-			// aapt resource value: 0x7f08009e
-			public const int mtrl_bottomappbar_fab_cradle_vertical_offset = 2131230878;
+			// aapt resource value: 0x7f09009e
+			public const int mtrl_bottomappbar_fab_cradle_vertical_offset = 2131296414;
 			
-			// aapt resource value: 0x7f08009f
-			public const int mtrl_bottomappbar_height = 2131230879;
+			// aapt resource value: 0x7f09009f
+			public const int mtrl_bottomappbar_height = 2131296415;
 			
-			// aapt resource value: 0x7f0800a0
-			public const int mtrl_btn_corner_radius = 2131230880;
+			// aapt resource value: 0x7f0900a0
+			public const int mtrl_btn_corner_radius = 2131296416;
 			
-			// aapt resource value: 0x7f0800a1
-			public const int mtrl_btn_dialog_btn_min_width = 2131230881;
+			// aapt resource value: 0x7f0900a1
+			public const int mtrl_btn_dialog_btn_min_width = 2131296417;
 			
-			// aapt resource value: 0x7f0800a2
-			public const int mtrl_btn_disabled_elevation = 2131230882;
+			// aapt resource value: 0x7f0900a2
+			public const int mtrl_btn_disabled_elevation = 2131296418;
 			
-			// aapt resource value: 0x7f0800a3
-			public const int mtrl_btn_disabled_z = 2131230883;
+			// aapt resource value: 0x7f0900a3
+			public const int mtrl_btn_disabled_z = 2131296419;
 			
-			// aapt resource value: 0x7f0800a4
-			public const int mtrl_btn_elevation = 2131230884;
+			// aapt resource value: 0x7f0900a4
+			public const int mtrl_btn_elevation = 2131296420;
 			
-			// aapt resource value: 0x7f0800a5
-			public const int mtrl_btn_focused_z = 2131230885;
+			// aapt resource value: 0x7f0900a5
+			public const int mtrl_btn_focused_z = 2131296421;
 			
-			// aapt resource value: 0x7f0800a6
-			public const int mtrl_btn_hovered_z = 2131230886;
+			// aapt resource value: 0x7f0900a6
+			public const int mtrl_btn_hovered_z = 2131296422;
 			
-			// aapt resource value: 0x7f0800a7
-			public const int mtrl_btn_icon_btn_padding_left = 2131230887;
+			// aapt resource value: 0x7f0900a7
+			public const int mtrl_btn_icon_btn_padding_left = 2131296423;
 			
-			// aapt resource value: 0x7f0800a8
-			public const int mtrl_btn_icon_padding = 2131230888;
+			// aapt resource value: 0x7f0900a8
+			public const int mtrl_btn_icon_padding = 2131296424;
 			
-			// aapt resource value: 0x7f0800a9
-			public const int mtrl_btn_inset = 2131230889;
+			// aapt resource value: 0x7f0900a9
+			public const int mtrl_btn_inset = 2131296425;
 			
-			// aapt resource value: 0x7f0800aa
-			public const int mtrl_btn_letter_spacing = 2131230890;
+			// aapt resource value: 0x7f0900aa
+			public const int mtrl_btn_letter_spacing = 2131296426;
 			
-			// aapt resource value: 0x7f0800ab
-			public const int mtrl_btn_padding_bottom = 2131230891;
+			// aapt resource value: 0x7f0900ab
+			public const int mtrl_btn_padding_bottom = 2131296427;
 			
-			// aapt resource value: 0x7f0800ac
-			public const int mtrl_btn_padding_left = 2131230892;
+			// aapt resource value: 0x7f0900ac
+			public const int mtrl_btn_padding_left = 2131296428;
 			
-			// aapt resource value: 0x7f0800ad
-			public const int mtrl_btn_padding_right = 2131230893;
+			// aapt resource value: 0x7f0900ad
+			public const int mtrl_btn_padding_right = 2131296429;
 			
-			// aapt resource value: 0x7f0800ae
-			public const int mtrl_btn_padding_top = 2131230894;
+			// aapt resource value: 0x7f0900ae
+			public const int mtrl_btn_padding_top = 2131296430;
 			
-			// aapt resource value: 0x7f0800af
-			public const int mtrl_btn_pressed_z = 2131230895;
+			// aapt resource value: 0x7f0900af
+			public const int mtrl_btn_pressed_z = 2131296431;
 			
-			// aapt resource value: 0x7f0800b0
-			public const int mtrl_btn_stroke_size = 2131230896;
+			// aapt resource value: 0x7f0900b0
+			public const int mtrl_btn_stroke_size = 2131296432;
 			
-			// aapt resource value: 0x7f0800b1
-			public const int mtrl_btn_text_btn_icon_padding = 2131230897;
+			// aapt resource value: 0x7f0900b1
+			public const int mtrl_btn_text_btn_icon_padding = 2131296433;
 			
-			// aapt resource value: 0x7f0800b2
-			public const int mtrl_btn_text_btn_padding_left = 2131230898;
+			// aapt resource value: 0x7f0900b2
+			public const int mtrl_btn_text_btn_padding_left = 2131296434;
 			
-			// aapt resource value: 0x7f0800b3
-			public const int mtrl_btn_text_btn_padding_right = 2131230899;
+			// aapt resource value: 0x7f0900b3
+			public const int mtrl_btn_text_btn_padding_right = 2131296435;
 			
-			// aapt resource value: 0x7f0800b4
-			public const int mtrl_btn_text_size = 2131230900;
+			// aapt resource value: 0x7f0900b4
+			public const int mtrl_btn_text_size = 2131296436;
 			
-			// aapt resource value: 0x7f0800b5
-			public const int mtrl_btn_z = 2131230901;
+			// aapt resource value: 0x7f0900b5
+			public const int mtrl_btn_z = 2131296437;
 			
-			// aapt resource value: 0x7f0800b6
-			public const int mtrl_card_elevation = 2131230902;
+			// aapt resource value: 0x7f0900b6
+			public const int mtrl_card_elevation = 2131296438;
 			
-			// aapt resource value: 0x7f0800b7
-			public const int mtrl_card_spacing = 2131230903;
+			// aapt resource value: 0x7f0900b7
+			public const int mtrl_card_spacing = 2131296439;
 			
-			// aapt resource value: 0x7f0800b8
-			public const int mtrl_chip_pressed_translation_z = 2131230904;
+			// aapt resource value: 0x7f0900b8
+			public const int mtrl_chip_pressed_translation_z = 2131296440;
 			
-			// aapt resource value: 0x7f0800b9
-			public const int mtrl_chip_text_size = 2131230905;
+			// aapt resource value: 0x7f0900b9
+			public const int mtrl_chip_text_size = 2131296441;
 			
-			// aapt resource value: 0x7f0800ba
-			public const int mtrl_fab_elevation = 2131230906;
+			// aapt resource value: 0x7f0900ba
+			public const int mtrl_fab_elevation = 2131296442;
 			
-			// aapt resource value: 0x7f0800bb
-			public const int mtrl_fab_translation_z_hovered_focused = 2131230907;
+			// aapt resource value: 0x7f0900bb
+			public const int mtrl_fab_translation_z_hovered_focused = 2131296443;
 			
-			// aapt resource value: 0x7f0800bc
-			public const int mtrl_fab_translation_z_pressed = 2131230908;
+			// aapt resource value: 0x7f0900bc
+			public const int mtrl_fab_translation_z_pressed = 2131296444;
 			
-			// aapt resource value: 0x7f0800bd
-			public const int mtrl_navigation_elevation = 2131230909;
+			// aapt resource value: 0x7f0900bd
+			public const int mtrl_navigation_elevation = 2131296445;
 			
-			// aapt resource value: 0x7f0800be
-			public const int mtrl_navigation_item_horizontal_padding = 2131230910;
+			// aapt resource value: 0x7f0900be
+			public const int mtrl_navigation_item_horizontal_padding = 2131296446;
 			
-			// aapt resource value: 0x7f0800bf
-			public const int mtrl_navigation_item_icon_padding = 2131230911;
+			// aapt resource value: 0x7f0900bf
+			public const int mtrl_navigation_item_icon_padding = 2131296447;
 			
-			// aapt resource value: 0x7f0800c0
-			public const int mtrl_snackbar_background_corner_radius = 2131230912;
+			// aapt resource value: 0x7f0900c0
+			public const int mtrl_snackbar_background_corner_radius = 2131296448;
 			
-			// aapt resource value: 0x7f0800c1
-			public const int mtrl_snackbar_margin = 2131230913;
+			// aapt resource value: 0x7f0900c1
+			public const int mtrl_snackbar_margin = 2131296449;
 			
-			// aapt resource value: 0x7f0800c2
-			public const int mtrl_textinput_box_bottom_offset = 2131230914;
+			// aapt resource value: 0x7f0900c2
+			public const int mtrl_textinput_box_bottom_offset = 2131296450;
 			
-			// aapt resource value: 0x7f0800c3
-			public const int mtrl_textinput_box_corner_radius_medium = 2131230915;
+			// aapt resource value: 0x7f0900c3
+			public const int mtrl_textinput_box_corner_radius_medium = 2131296451;
 			
-			// aapt resource value: 0x7f0800c4
-			public const int mtrl_textinput_box_corner_radius_small = 2131230916;
+			// aapt resource value: 0x7f0900c4
+			public const int mtrl_textinput_box_corner_radius_small = 2131296452;
 			
-			// aapt resource value: 0x7f0800c5
-			public const int mtrl_textinput_box_label_cutout_padding = 2131230917;
+			// aapt resource value: 0x7f0900c5
+			public const int mtrl_textinput_box_label_cutout_padding = 2131296453;
 			
-			// aapt resource value: 0x7f0800c6
-			public const int mtrl_textinput_box_padding_end = 2131230918;
+			// aapt resource value: 0x7f0900c6
+			public const int mtrl_textinput_box_padding_end = 2131296454;
 			
-			// aapt resource value: 0x7f0800c7
-			public const int mtrl_textinput_box_stroke_width_default = 2131230919;
+			// aapt resource value: 0x7f0900c7
+			public const int mtrl_textinput_box_stroke_width_default = 2131296455;
 			
-			// aapt resource value: 0x7f0800c8
-			public const int mtrl_textinput_box_stroke_width_focused = 2131230920;
+			// aapt resource value: 0x7f0900c8
+			public const int mtrl_textinput_box_stroke_width_focused = 2131296456;
 			
-			// aapt resource value: 0x7f0800c9
-			public const int mtrl_textinput_outline_box_expanded_padding = 2131230921;
+			// aapt resource value: 0x7f0900c9
+			public const int mtrl_textinput_outline_box_expanded_padding = 2131296457;
 			
-			// aapt resource value: 0x7f0800ca
-			public const int mtrl_toolbar_default_height = 2131230922;
+			// aapt resource value: 0x7f0900ca
+			public const int mtrl_toolbar_default_height = 2131296458;
 			
-			// aapt resource value: 0x7f0800d8
-			public const int notification_action_icon_size = 2131230936;
+			// aapt resource value: 0x7f0900d8
+			public const int notification_action_icon_size = 2131296472;
 			
-			// aapt resource value: 0x7f0800d9
-			public const int notification_action_text_size = 2131230937;
+			// aapt resource value: 0x7f0900d9
+			public const int notification_action_text_size = 2131296473;
 			
-			// aapt resource value: 0x7f0800da
-			public const int notification_big_circle_margin = 2131230938;
+			// aapt resource value: 0x7f0900da
+			public const int notification_big_circle_margin = 2131296474;
 			
-			// aapt resource value: 0x7f0800ce
-			public const int notification_content_margin_start = 2131230926;
+			// aapt resource value: 0x7f0900ce
+			public const int notification_content_margin_start = 2131296462;
 			
-			// aapt resource value: 0x7f0800db
-			public const int notification_large_icon_height = 2131230939;
+			// aapt resource value: 0x7f0900db
+			public const int notification_large_icon_height = 2131296475;
 			
-			// aapt resource value: 0x7f0800dc
-			public const int notification_large_icon_width = 2131230940;
+			// aapt resource value: 0x7f0900dc
+			public const int notification_large_icon_width = 2131296476;
 			
-			// aapt resource value: 0x7f0800cf
-			public const int notification_main_column_padding_top = 2131230927;
+			// aapt resource value: 0x7f0900cf
+			public const int notification_main_column_padding_top = 2131296463;
 			
-			// aapt resource value: 0x7f0800d0
-			public const int notification_media_narrow_margin = 2131230928;
+			// aapt resource value: 0x7f0900d0
+			public const int notification_media_narrow_margin = 2131296464;
 			
-			// aapt resource value: 0x7f0800dd
-			public const int notification_right_icon_size = 2131230941;
+			// aapt resource value: 0x7f0900dd
+			public const int notification_right_icon_size = 2131296477;
 			
-			// aapt resource value: 0x7f0800cd
-			public const int notification_right_side_padding_top = 2131230925;
+			// aapt resource value: 0x7f0900cd
+			public const int notification_right_side_padding_top = 2131296461;
 			
-			// aapt resource value: 0x7f0800de
-			public const int notification_small_icon_background_padding = 2131230942;
+			// aapt resource value: 0x7f0900de
+			public const int notification_small_icon_background_padding = 2131296478;
 			
-			// aapt resource value: 0x7f0800df
-			public const int notification_small_icon_size_as_large = 2131230943;
+			// aapt resource value: 0x7f0900df
+			public const int notification_small_icon_size_as_large = 2131296479;
 			
-			// aapt resource value: 0x7f0800e0
-			public const int notification_subtext_size = 2131230944;
+			// aapt resource value: 0x7f0900e0
+			public const int notification_subtext_size = 2131296480;
 			
-			// aapt resource value: 0x7f0800e1
-			public const int notification_top_pad = 2131230945;
+			// aapt resource value: 0x7f0900e1
+			public const int notification_top_pad = 2131296481;
 			
-			// aapt resource value: 0x7f0800e2
-			public const int notification_top_pad_large_text = 2131230946;
+			// aapt resource value: 0x7f0900e2
+			public const int notification_top_pad_large_text = 2131296482;
 			
-			// aapt resource value: 0x7f08006b
-			public const int subtitle_corner_radius = 2131230827;
+			// aapt resource value: 0x7f09006b
+			public const int subtitle_corner_radius = 2131296363;
 			
-			// aapt resource value: 0x7f08006c
-			public const int subtitle_outline_width = 2131230828;
+			// aapt resource value: 0x7f09006c
+			public const int subtitle_outline_width = 2131296364;
 			
-			// aapt resource value: 0x7f08006d
-			public const int subtitle_shadow_offset = 2131230829;
+			// aapt resource value: 0x7f09006d
+			public const int subtitle_shadow_offset = 2131296365;
 			
-			// aapt resource value: 0x7f08006e
-			public const int subtitle_shadow_radius = 2131230830;
+			// aapt resource value: 0x7f09006e
+			public const int subtitle_shadow_radius = 2131296366;
 			
-			// aapt resource value: 0x7f080063
-			public const int tooltip_corner_radius = 2131230819;
+			// aapt resource value: 0x7f090063
+			public const int tooltip_corner_radius = 2131296355;
 			
-			// aapt resource value: 0x7f080064
-			public const int tooltip_horizontal_padding = 2131230820;
+			// aapt resource value: 0x7f090064
+			public const int tooltip_horizontal_padding = 2131296356;
 			
-			// aapt resource value: 0x7f080065
-			public const int tooltip_margin = 2131230821;
+			// aapt resource value: 0x7f090065
+			public const int tooltip_margin = 2131296357;
 			
-			// aapt resource value: 0x7f080066
-			public const int tooltip_precise_anchor_extra_offset = 2131230822;
+			// aapt resource value: 0x7f090066
+			public const int tooltip_precise_anchor_extra_offset = 2131296358;
 			
-			// aapt resource value: 0x7f080067
-			public const int tooltip_precise_anchor_threshold = 2131230823;
+			// aapt resource value: 0x7f090067
+			public const int tooltip_precise_anchor_threshold = 2131296359;
 			
-			// aapt resource value: 0x7f080068
-			public const int tooltip_vertical_padding = 2131230824;
+			// aapt resource value: 0x7f090068
+			public const int tooltip_vertical_padding = 2131296360;
 			
-			// aapt resource value: 0x7f080069
-			public const int tooltip_y_offset_non_touch = 2131230825;
+			// aapt resource value: 0x7f090069
+			public const int tooltip_y_offset_non_touch = 2131296361;
 			
-			// aapt resource value: 0x7f08006a
-			public const int tooltip_y_offset_touch = 2131230826;
+			// aapt resource value: 0x7f09006a
+			public const int tooltip_y_offset_touch = 2131296362;
 			
 			static Dimension()
 			{
@@ -11514,788 +11514,785 @@ namespace BLE.Client.Droid
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f09003b
-			public const int ALT = 2131296315;
+			// aapt resource value: 0x7f0a003b
+			public const int ALT = 2131361851;
 			
-			// aapt resource value: 0x7f09003c
-			public const int CTRL = 2131296316;
+			// aapt resource value: 0x7f0a003c
+			public const int CTRL = 2131361852;
 			
-			// aapt resource value: 0x7f09003d
-			public const int FUNCTION = 2131296317;
+			// aapt resource value: 0x7f0a003d
+			public const int FUNCTION = 2131361853;
 			
-			// aapt resource value: 0x7f09003e
-			public const int META = 2131296318;
+			// aapt resource value: 0x7f0a003e
+			public const int META = 2131361854;
 			
-			// aapt resource value: 0x7f090024
-			public const int MvvmCrossTagId = 2131296292;
+			// aapt resource value: 0x7f0a0024
+			public const int MvvmCrossTagId = 2131361828;
 			
-			// aapt resource value: 0x7f090025
-			public const int MvxBindingTagUnique = 2131296293;
+			// aapt resource value: 0x7f0a0025
+			public const int MvxBindingTagUnique = 2131361829;
 			
-			// aapt resource value: 0x7f09003f
-			public const int SHIFT = 2131296319;
+			// aapt resource value: 0x7f0a003f
+			public const int SHIFT = 2131361855;
 			
-			// aapt resource value: 0x7f090040
-			public const int SYM = 2131296320;
+			// aapt resource value: 0x7f0a0040
+			public const int SYM = 2131361856;
 			
-			// aapt resource value: 0x7f0900ea
-			public const int action0 = 2131296490;
+			// aapt resource value: 0x7f0a00ea
+			public const int action0 = 2131362026;
 			
-			// aapt resource value: 0x7f09008f
-			public const int action_bar = 2131296399;
+			// aapt resource value: 0x7f0a008f
+			public const int action_bar = 2131361935;
 			
-			// aapt resource value: 0x7f090001
-			public const int action_bar_activity_content = 2131296257;
+			// aapt resource value: 0x7f0a0001
+			public const int action_bar_activity_content = 2131361793;
 			
-			// aapt resource value: 0x7f09008e
-			public const int action_bar_container = 2131296398;
+			// aapt resource value: 0x7f0a008e
+			public const int action_bar_container = 2131361934;
 			
-			// aapt resource value: 0x7f09008a
-			public const int action_bar_root = 2131296394;
+			// aapt resource value: 0x7f0a008a
+			public const int action_bar_root = 2131361930;
 			
-			// aapt resource value: 0x7f090002
-			public const int action_bar_spinner = 2131296258;
+			// aapt resource value: 0x7f0a0002
+			public const int action_bar_spinner = 2131361794;
 			
-			// aapt resource value: 0x7f09006c
-			public const int action_bar_subtitle = 2131296364;
+			// aapt resource value: 0x7f0a006c
+			public const int action_bar_subtitle = 2131361900;
 			
-			// aapt resource value: 0x7f09006b
-			public const int action_bar_title = 2131296363;
+			// aapt resource value: 0x7f0a006b
+			public const int action_bar_title = 2131361899;
 			
-			// aapt resource value: 0x7f0900e7
-			public const int action_container = 2131296487;
+			// aapt resource value: 0x7f0a00e7
+			public const int action_container = 2131362023;
 			
-			// aapt resource value: 0x7f090090
-			public const int action_context_bar = 2131296400;
+			// aapt resource value: 0x7f0a0090
+			public const int action_context_bar = 2131361936;
 			
-			// aapt resource value: 0x7f0900ee
-			public const int action_divider = 2131296494;
+			// aapt resource value: 0x7f0a00ee
+			public const int action_divider = 2131362030;
 			
-			// aapt resource value: 0x7f0900e8
-			public const int action_image = 2131296488;
+			// aapt resource value: 0x7f0a00e8
+			public const int action_image = 2131362024;
 			
-			// aapt resource value: 0x7f090003
-			public const int action_menu_divider = 2131296259;
+			// aapt resource value: 0x7f0a0003
+			public const int action_menu_divider = 2131361795;
 			
-			// aapt resource value: 0x7f090004
-			public const int action_menu_presenter = 2131296260;
+			// aapt resource value: 0x7f0a0004
+			public const int action_menu_presenter = 2131361796;
 			
-			// aapt resource value: 0x7f09008c
-			public const int action_mode_bar = 2131296396;
+			// aapt resource value: 0x7f0a008c
+			public const int action_mode_bar = 2131361932;
 			
-			// aapt resource value: 0x7f09008b
-			public const int action_mode_bar_stub = 2131296395;
+			// aapt resource value: 0x7f0a008b
+			public const int action_mode_bar_stub = 2131361931;
 			
-			// aapt resource value: 0x7f09006d
-			public const int action_mode_close_button = 2131296365;
+			// aapt resource value: 0x7f0a006d
+			public const int action_mode_close_button = 2131361901;
 			
-			// aapt resource value: 0x7f0900e9
-			public const int action_text = 2131296489;
+			// aapt resource value: 0x7f0a00e9
+			public const int action_text = 2131362025;
 			
-			// aapt resource value: 0x7f0900f7
-			public const int actions = 2131296503;
+			// aapt resource value: 0x7f0a00f7
+			public const int actions = 2131362039;
 			
-			// aapt resource value: 0x7f09006e
-			public const int activity_chooser_view_content = 2131296366;
+			// aapt resource value: 0x7f0a006e
+			public const int activity_chooser_view_content = 2131361902;
 			
-			// aapt resource value: 0x7f090030
-			public const int add = 2131296304;
+			// aapt resource value: 0x7f0a0030
+			public const int add = 2131361840;
 			
-			// aapt resource value: 0x7f090081
-			public const int alertTitle = 2131296385;
+			// aapt resource value: 0x7f0a0081
+			public const int alertTitle = 2131361921;
 			
-			// aapt resource value: 0x7f090066
-			public const int all = 2131296358;
+			// aapt resource value: 0x7f0a0066
+			public const int all = 2131361894;
 			
-			// aapt resource value: 0x7f090041
-			public const int always = 2131296321;
+			// aapt resource value: 0x7f0a0041
+			public const int always = 2131361857;
 			
-			// aapt resource value: 0x7f090067
-			public const int async = 2131296359;
+			// aapt resource value: 0x7f0a0067
+			public const int async = 2131361895;
 			
-			// aapt resource value: 0x7f09004f
-			public const int auto = 2131296335;
+			// aapt resource value: 0x7f0a004f
+			public const int auto = 2131361871;
 			
-			// aapt resource value: 0x7f090038
-			public const int beginning = 2131296312;
+			// aapt resource value: 0x7f0a0038
+			public const int beginning = 2131361848;
 			
-			// aapt resource value: 0x7f090068
-			public const int blocking = 2131296360;
+			// aapt resource value: 0x7f0a0068
+			public const int blocking = 2131361896;
 			
-			// aapt resource value: 0x7f090046
-			public const int bottom = 2131296326;
+			// aapt resource value: 0x7f0a0046
+			public const int bottom = 2131361862;
 			
-			// aapt resource value: 0x7f09009f
-			public const int bottomtab_navarea = 2131296415;
+			// aapt resource value: 0x7f0a009f
+			public const int bottomtab_navarea = 2131361951;
 			
-			// aapt resource value: 0x7f0900a0
-			public const int bottomtab_tabbar = 2131296416;
+			// aapt resource value: 0x7f0a00a0
+			public const int bottomtab_tabbar = 2131361952;
 			
-			// aapt resource value: 0x7f0900a2
-			public const int browser_actions_header_text = 2131296418;
+			// aapt resource value: 0x7f0a00a2
+			public const int browser_actions_header_text = 2131361954;
 			
-			// aapt resource value: 0x7f0900a4
-			public const int browser_actions_menu_item_icon = 2131296420;
+			// aapt resource value: 0x7f0a00a4
+			public const int browser_actions_menu_item_icon = 2131361956;
 			
-			// aapt resource value: 0x7f0900a5
-			public const int browser_actions_menu_item_text = 2131296421;
+			// aapt resource value: 0x7f0a00a5
+			public const int browser_actions_menu_item_text = 2131361957;
 			
-			// aapt resource value: 0x7f0900a3
-			public const int browser_actions_menu_items = 2131296419;
+			// aapt resource value: 0x7f0a00a3
+			public const int browser_actions_menu_items = 2131361955;
 			
-			// aapt resource value: 0x7f0900a1
-			public const int browser_actions_menu_view = 2131296417;
+			// aapt resource value: 0x7f0a00a1
+			public const int browser_actions_menu_view = 2131361953;
 			
-			// aapt resource value: 0x7f090074
-			public const int buttonPanel = 2131296372;
+			// aapt resource value: 0x7f0a0074
+			public const int buttonPanel = 2131361908;
 			
-			// aapt resource value: 0x7f0900eb
-			public const int cancel_action = 2131296491;
+			// aapt resource value: 0x7f0a00eb
+			public const int cancel_action = 2131362027;
 			
-			// aapt resource value: 0x7f09004e
-			public const int center = 2131296334;
+			// aapt resource value: 0x7f0a004e
+			public const int center = 2131361870;
 			
-			// aapt resource value: 0x7f090053
-			public const int center_horizontal = 2131296339;
+			// aapt resource value: 0x7f0a0053
+			public const int center_horizontal = 2131361875;
 			
-			// aapt resource value: 0x7f090054
-			public const int center_vertical = 2131296340;
+			// aapt resource value: 0x7f0a0054
+			public const int center_vertical = 2131361876;
 			
-			// aapt resource value: 0x7f090088
-			public const int checkbox = 2131296392;
+			// aapt resource value: 0x7f0a0088
+			public const int checkbox = 2131361928;
 			
-			// aapt resource value: 0x7f0900f3
-			public const int chronometer = 2131296499;
+			// aapt resource value: 0x7f0a00f3
+			public const int chronometer = 2131362035;
 			
-			// aapt resource value: 0x7f090063
-			public const int clip_horizontal = 2131296355;
+			// aapt resource value: 0x7f0a0063
+			public const int clip_horizontal = 2131361891;
 			
-			// aapt resource value: 0x7f090064
-			public const int clip_vertical = 2131296356;
+			// aapt resource value: 0x7f0a0064
+			public const int clip_vertical = 2131361892;
 			
-			// aapt resource value: 0x7f090042
-			public const int collapseActionView = 2131296322;
+			// aapt resource value: 0x7f0a0042
+			public const int collapseActionView = 2131361858;
 			
-			// aapt resource value: 0x7f0900a8
-			public const int container = 2131296424;
+			// aapt resource value: 0x7f0a00a8
+			public const int container = 2131361960;
 			
-			// aapt resource value: 0x7f090084
-			public const int content = 2131296388;
+			// aapt resource value: 0x7f0a0084
+			public const int content = 2131361924;
 			
-			// aapt resource value: 0x7f090077
-			public const int contentPanel = 2131296375;
+			// aapt resource value: 0x7f0a0077
+			public const int contentPanel = 2131361911;
 			
-			// aapt resource value: 0x7f0900a9
-			public const int coordinator = 2131296425;
+			// aapt resource value: 0x7f0a00a9
+			public const int coordinator = 2131361961;
 			
-			// aapt resource value: 0x7f09007e
-			public const int custom = 2131296382;
+			// aapt resource value: 0x7f0a007e
+			public const int custom = 2131361918;
 			
-			// aapt resource value: 0x7f09007d
-			public const int customPanel = 2131296381;
+			// aapt resource value: 0x7f0a007d
+			public const int customPanel = 2131361917;
 			
-			// aapt resource value: 0x7f09008d
-			public const int decor_content_parent = 2131296397;
+			// aapt resource value: 0x7f0a008d
+			public const int decor_content_parent = 2131361933;
 			
-			// aapt resource value: 0x7f090071
-			public const int default_activity_button = 2131296369;
+			// aapt resource value: 0x7f0a0071
+			public const int default_activity_button = 2131361905;
 			
-			// aapt resource value: 0x7f0900ab
-			public const int design_bottom_sheet = 2131296427;
+			// aapt resource value: 0x7f0a00ab
+			public const int design_bottom_sheet = 2131361963;
 			
-			// aapt resource value: 0x7f0900b0
-			public const int design_menu_item_action_area = 2131296432;
+			// aapt resource value: 0x7f0a00b0
+			public const int design_menu_item_action_area = 2131361968;
 			
-			// aapt resource value: 0x7f0900af
-			public const int design_menu_item_action_area_stub = 2131296431;
+			// aapt resource value: 0x7f0a00af
+			public const int design_menu_item_action_area_stub = 2131361967;
 			
-			// aapt resource value: 0x7f0900ae
-			public const int design_menu_item_text = 2131296430;
+			// aapt resource value: 0x7f0a00ae
+			public const int design_menu_item_text = 2131361966;
 			
-			// aapt resource value: 0x7f0900ad
-			public const int design_navigation_view = 2131296429;
+			// aapt resource value: 0x7f0a00ad
+			public const int design_navigation_view = 2131361965;
 			
-			// aapt resource value: 0x7f090029
-			public const int disableHome = 2131296297;
+			// aapt resource value: 0x7f0a0029
+			public const int disableHome = 2131361833;
 			
-			// aapt resource value: 0x7f090091
-			public const int edit_query = 2131296401;
+			// aapt resource value: 0x7f0a0091
+			public const int edit_query = 2131361937;
 			
-			// aapt resource value: 0x7f090039
-			public const int end = 2131296313;
+			// aapt resource value: 0x7f0a0039
+			public const int end = 2131361849;
 			
-			// aapt resource value: 0x7f0900f9
-			public const int end_padder = 2131296505;
+			// aapt resource value: 0x7f0a00f9
+			public const int end_padder = 2131362041;
 			
-			// aapt resource value: 0x7f090048
-			public const int enterAlways = 2131296328;
+			// aapt resource value: 0x7f0a0048
+			public const int enterAlways = 2131361864;
 			
-			// aapt resource value: 0x7f090049
-			public const int enterAlwaysCollapsed = 2131296329;
+			// aapt resource value: 0x7f0a0049
+			public const int enterAlwaysCollapsed = 2131361865;
 			
-			// aapt resource value: 0x7f09004a
-			public const int exitUntilCollapsed = 2131296330;
+			// aapt resource value: 0x7f0a004a
+			public const int exitUntilCollapsed = 2131361866;
 			
-			// aapt resource value: 0x7f09006f
-			public const int expand_activities_button = 2131296367;
+			// aapt resource value: 0x7f0a006f
+			public const int expand_activities_button = 2131361903;
 			
-			// aapt resource value: 0x7f090087
-			public const int expanded_menu = 2131296391;
+			// aapt resource value: 0x7f0a0087
+			public const int expanded_menu = 2131361927;
 			
-			// aapt resource value: 0x7f090060
-			public const int fill = 2131296352;
+			// aapt resource value: 0x7f0a0060
+			public const int fill = 2131361888;
 			
-			// aapt resource value: 0x7f090065
-			public const int fill_horizontal = 2131296357;
+			// aapt resource value: 0x7f0a0065
+			public const int fill_horizontal = 2131361893;
 			
-			// aapt resource value: 0x7f090055
-			public const int fill_vertical = 2131296341;
+			// aapt resource value: 0x7f0a0055
+			public const int fill_vertical = 2131361877;
 			
-			// aapt resource value: 0x7f090061
-			public const int filled = 2131296353;
+			// aapt resource value: 0x7f0a0061
+			public const int filled = 2131361889;
 			
-			// aapt resource value: 0x7f09005e
-			public const int @fixed = 2131296350;
+			// aapt resource value: 0x7f0a005e
+			public const int @fixed = 2131361886;
 			
-			// aapt resource value: 0x7f0900b2
-			public const int flyoutcontent_appbar = 2131296434;
+			// aapt resource value: 0x7f0a00b2
+			public const int flyoutcontent_appbar = 2131361970;
 			
-			// aapt resource value: 0x7f0900b3
-			public const int flyoutcontent_recycler = 2131296435;
+			// aapt resource value: 0x7f0a00b3
+			public const int flyoutcontent_recycler = 2131361971;
 			
-			// aapt resource value: 0x7f090069
-			public const int forever = 2131296361;
+			// aapt resource value: 0x7f0a0069
+			public const int forever = 2131361897;
 			
-			// aapt resource value: 0x7f09000a
-			public const int ghost_view = 2131296266;
+			// aapt resource value: 0x7f0a000a
+			public const int ghost_view = 2131361802;
 			
-			// aapt resource value: 0x7f090083
-			public const int group_divider = 2131296387;
+			// aapt resource value: 0x7f0a0083
+			public const int group_divider = 2131361923;
 			
-			// aapt resource value: 0x7f090005
-			public const int home = 2131296261;
+			// aapt resource value: 0x7f0a0005
+			public const int home = 2131361797;
 			
-			// aapt resource value: 0x7f09002a
-			public const int homeAsUp = 2131296298;
+			// aapt resource value: 0x7f0a002a
+			public const int homeAsUp = 2131361834;
 			
-			// aapt resource value: 0x7f090073
-			public const int icon = 2131296371;
+			// aapt resource value: 0x7f0a0073
+			public const int icon = 2131361907;
 			
-			// aapt resource value: 0x7f0900f8
-			public const int icon_group = 2131296504;
+			// aapt resource value: 0x7f0a00f8
+			public const int icon_group = 2131362040;
 			
-			// aapt resource value: 0x7f090043
-			public const int ifRoom = 2131296323;
+			// aapt resource value: 0x7f0a0043
+			public const int ifRoom = 2131361859;
 			
-			// aapt resource value: 0x7f090070
-			public const int image = 2131296368;
+			// aapt resource value: 0x7f0a0070
+			public const int image = 2131361904;
 			
-			// aapt resource value: 0x7f0900f4
-			public const int info = 2131296500;
+			// aapt resource value: 0x7f0a00f4
+			public const int info = 2131362036;
 			
-			// aapt resource value: 0x7f09006a
-			public const int italic = 2131296362;
+			// aapt resource value: 0x7f0a006a
+			public const int italic = 2131361898;
 			
-			// aapt resource value: 0x7f090000
-			public const int item_touch_helper_previous_elevation = 2131296256;
+			// aapt resource value: 0x7f0a0000
+			public const int item_touch_helper_previous_elevation = 2131361792;
 			
-			// aapt resource value: 0x7f090050
-			public const int labeled = 2131296336;
+			// aapt resource value: 0x7f0a0050
+			public const int labeled = 2131361872;
 			
-			// aapt resource value: 0x7f0900a7
-			public const int largeLabel = 2131296423;
+			// aapt resource value: 0x7f0a00a7
+			public const int largeLabel = 2131361959;
 			
-			// aapt resource value: 0x7f090056
-			public const int left = 2131296342;
+			// aapt resource value: 0x7f0a0056
+			public const int left = 2131361878;
 			
-			// aapt resource value: 0x7f09001c
-			public const int line1 = 2131296284;
+			// aapt resource value: 0x7f0a001c
+			public const int line1 = 2131361820;
 			
-			// aapt resource value: 0x7f09001d
-			public const int line3 = 2131296285;
+			// aapt resource value: 0x7f0a001d
+			public const int line3 = 2131361821;
 			
-			// aapt resource value: 0x7f090026
-			public const int listMode = 2131296294;
+			// aapt resource value: 0x7f0a0026
+			public const int listMode = 2131361830;
 			
-			// aapt resource value: 0x7f090072
-			public const int list_item = 2131296370;
+			// aapt resource value: 0x7f0a0072
+			public const int list_item = 2131361906;
 			
-			// aapt resource value: 0x7f0900b6
-			public const int loadingImage = 2131296438;
+			// aapt resource value: 0x7f0a00b6
+			public const int loadingImage = 2131361974;
 			
-			// aapt resource value: 0x7f0900b4
-			public const int loadingProgressBar = 2131296436;
+			// aapt resource value: 0x7f0a00b4
+			public const int loadingProgressBar = 2131361972;
 			
-			// aapt resource value: 0x7f0900b7
-			public const int loadingProgressWheel = 2131296439;
+			// aapt resource value: 0x7f0a00b7
+			public const int loadingProgressWheel = 2131361975;
 			
-			// aapt resource value: 0x7f0900fa
-			public const int main_appbar = 2131296506;
+			// aapt resource value: 0x7f0a00fa
+			public const int main_appbar = 2131362042;
 			
-			// aapt resource value: 0x7f0900fd
-			public const int main_scrollview = 2131296509;
+			// aapt resource value: 0x7f0a00fc
+			public const int main_tablayout = 2131362044;
 			
-			// aapt resource value: 0x7f0900fc
-			public const int main_tablayout = 2131296508;
+			// aapt resource value: 0x7f0a00fb
+			public const int main_toolbar = 2131362043;
 			
-			// aapt resource value: 0x7f0900fb
-			public const int main_toolbar = 2131296507;
+			// aapt resource value: 0x7f0a00fd
+			public const int main_viewpager = 2131362045;
 			
-			// aapt resource value: 0x7f090104
-			public const int masked = 2131296516;
+			// aapt resource value: 0x7f0a0103
+			public const int masked = 2131362051;
 			
-			// aapt resource value: 0x7f0900ed
-			public const int media_actions = 2131296493;
+			// aapt resource value: 0x7f0a00ed
+			public const int media_actions = 2131362029;
 			
-			// aapt resource value: 0x7f09009e
-			public const int message = 2131296414;
+			// aapt resource value: 0x7f0a009e
+			public const int message = 2131361950;
 			
-			// aapt resource value: 0x7f09003a
-			public const int middle = 2131296314;
+			// aapt resource value: 0x7f0a003a
+			public const int middle = 2131361850;
 			
-			// aapt resource value: 0x7f09005b
-			public const int mini = 2131296347;
+			// aapt resource value: 0x7f0a005b
+			public const int mini = 2131361883;
 			
-			// aapt resource value: 0x7f0900d4
-			public const int mr_art = 2131296468;
+			// aapt resource value: 0x7f0a00d4
+			public const int mr_art = 2131362004;
 			
-			// aapt resource value: 0x7f0900c5
-			public const int mr_cast_checkbox = 2131296453;
+			// aapt resource value: 0x7f0a00c5
+			public const int mr_cast_checkbox = 2131361989;
 			
-			// aapt resource value: 0x7f0900be
-			public const int mr_cast_close_button = 2131296446;
+			// aapt resource value: 0x7f0a00be
+			public const int mr_cast_close_button = 2131361982;
 			
-			// aapt resource value: 0x7f0900b9
-			public const int mr_cast_group_icon = 2131296441;
+			// aapt resource value: 0x7f0a00b9
+			public const int mr_cast_group_icon = 2131361977;
 			
-			// aapt resource value: 0x7f0900ba
-			public const int mr_cast_group_name = 2131296442;
+			// aapt resource value: 0x7f0a00ba
+			public const int mr_cast_group_name = 2131361978;
 			
-			// aapt resource value: 0x7f0900b8
-			public const int mr_cast_list = 2131296440;
+			// aapt resource value: 0x7f0a00b8
+			public const int mr_cast_list = 2131361976;
 			
-			// aapt resource value: 0x7f0900bd
-			public const int mr_cast_meta = 2131296445;
+			// aapt resource value: 0x7f0a00bd
+			public const int mr_cast_meta = 2131361981;
 			
-			// aapt resource value: 0x7f0900bf
-			public const int mr_cast_meta_art = 2131296447;
+			// aapt resource value: 0x7f0a00bf
+			public const int mr_cast_meta_art = 2131361983;
 			
-			// aapt resource value: 0x7f0900c1
-			public const int mr_cast_meta_subtitle = 2131296449;
+			// aapt resource value: 0x7f0a00c1
+			public const int mr_cast_meta_subtitle = 2131361985;
 			
-			// aapt resource value: 0x7f0900c0
-			public const int mr_cast_meta_title = 2131296448;
+			// aapt resource value: 0x7f0a00c0
+			public const int mr_cast_meta_title = 2131361984;
 			
-			// aapt resource value: 0x7f0900c3
-			public const int mr_cast_route_icon = 2131296451;
+			// aapt resource value: 0x7f0a00c3
+			public const int mr_cast_route_icon = 2131361987;
 			
-			// aapt resource value: 0x7f0900c4
-			public const int mr_cast_route_name = 2131296452;
+			// aapt resource value: 0x7f0a00c4
+			public const int mr_cast_route_name = 2131361988;
 			
-			// aapt resource value: 0x7f0900c2
-			public const int mr_cast_stop_button = 2131296450;
+			// aapt resource value: 0x7f0a00c2
+			public const int mr_cast_stop_button = 2131361986;
 			
-			// aapt resource value: 0x7f0900c6
-			public const int mr_cast_volume_layout = 2131296454;
+			// aapt resource value: 0x7f0a00c6
+			public const int mr_cast_volume_layout = 2131361990;
 			
-			// aapt resource value: 0x7f0900c7
-			public const int mr_cast_volume_slider = 2131296455;
+			// aapt resource value: 0x7f0a00c7
+			public const int mr_cast_volume_slider = 2131361991;
 			
-			// aapt resource value: 0x7f0900c9
-			public const int mr_chooser_list = 2131296457;
+			// aapt resource value: 0x7f0a00c9
+			public const int mr_chooser_list = 2131361993;
 			
-			// aapt resource value: 0x7f0900cc
-			public const int mr_chooser_route_desc = 2131296460;
+			// aapt resource value: 0x7f0a00cc
+			public const int mr_chooser_route_desc = 2131361996;
 			
-			// aapt resource value: 0x7f0900ca
-			public const int mr_chooser_route_icon = 2131296458;
+			// aapt resource value: 0x7f0a00ca
+			public const int mr_chooser_route_icon = 2131361994;
 			
-			// aapt resource value: 0x7f0900cb
-			public const int mr_chooser_route_name = 2131296459;
+			// aapt resource value: 0x7f0a00cb
+			public const int mr_chooser_route_name = 2131361995;
 			
-			// aapt resource value: 0x7f0900c8
-			public const int mr_chooser_title = 2131296456;
+			// aapt resource value: 0x7f0a00c8
+			public const int mr_chooser_title = 2131361992;
 			
-			// aapt resource value: 0x7f0900d1
-			public const int mr_close = 2131296465;
+			// aapt resource value: 0x7f0a00d1
+			public const int mr_close = 2131362001;
 			
-			// aapt resource value: 0x7f0900d7
-			public const int mr_control_divider = 2131296471;
+			// aapt resource value: 0x7f0a00d7
+			public const int mr_control_divider = 2131362007;
 			
-			// aapt resource value: 0x7f0900e2
-			public const int mr_control_playback_ctrl = 2131296482;
+			// aapt resource value: 0x7f0a00e2
+			public const int mr_control_playback_ctrl = 2131362018;
 			
-			// aapt resource value: 0x7f0900e5
-			public const int mr_control_subtitle = 2131296485;
+			// aapt resource value: 0x7f0a00e5
+			public const int mr_control_subtitle = 2131362021;
 			
-			// aapt resource value: 0x7f0900e4
-			public const int mr_control_title = 2131296484;
+			// aapt resource value: 0x7f0a00e4
+			public const int mr_control_title = 2131362020;
 			
-			// aapt resource value: 0x7f0900e3
-			public const int mr_control_title_container = 2131296483;
+			// aapt resource value: 0x7f0a00e3
+			public const int mr_control_title_container = 2131362019;
 			
-			// aapt resource value: 0x7f0900d2
-			public const int mr_custom_control = 2131296466;
+			// aapt resource value: 0x7f0a00d2
+			public const int mr_custom_control = 2131362002;
 			
-			// aapt resource value: 0x7f0900d3
-			public const int mr_default_control = 2131296467;
+			// aapt resource value: 0x7f0a00d3
+			public const int mr_default_control = 2131362003;
 			
-			// aapt resource value: 0x7f0900ce
-			public const int mr_dialog_area = 2131296462;
+			// aapt resource value: 0x7f0a00ce
+			public const int mr_dialog_area = 2131361998;
 			
-			// aapt resource value: 0x7f0900dd
-			public const int mr_dialog_header_name = 2131296477;
+			// aapt resource value: 0x7f0a00dd
+			public const int mr_dialog_header_name = 2131362013;
 			
-			// aapt resource value: 0x7f0900cd
-			public const int mr_expandable_area = 2131296461;
+			// aapt resource value: 0x7f0a00cd
+			public const int mr_expandable_area = 2131361997;
 			
-			// aapt resource value: 0x7f0900e6
-			public const int mr_group_expand_collapse = 2131296486;
+			// aapt resource value: 0x7f0a00e6
+			public const int mr_group_expand_collapse = 2131362022;
 			
-			// aapt resource value: 0x7f0900bb
-			public const int mr_group_volume_route_name = 2131296443;
+			// aapt resource value: 0x7f0a00bb
+			public const int mr_group_volume_route_name = 2131361979;
 			
-			// aapt resource value: 0x7f0900bc
-			public const int mr_group_volume_slider = 2131296444;
+			// aapt resource value: 0x7f0a00bc
+			public const int mr_group_volume_slider = 2131361980;
 			
-			// aapt resource value: 0x7f0900d5
-			public const int mr_media_main_control = 2131296469;
+			// aapt resource value: 0x7f0a00d5
+			public const int mr_media_main_control = 2131362005;
 			
-			// aapt resource value: 0x7f0900d0
-			public const int mr_name = 2131296464;
+			// aapt resource value: 0x7f0a00d0
+			public const int mr_name = 2131362000;
 			
-			// aapt resource value: 0x7f0900de
-			public const int mr_picker_close_button = 2131296478;
+			// aapt resource value: 0x7f0a00de
+			public const int mr_picker_close_button = 2131362014;
 			
-			// aapt resource value: 0x7f0900df
-			public const int mr_picker_list = 2131296479;
+			// aapt resource value: 0x7f0a00df
+			public const int mr_picker_list = 2131362015;
 			
-			// aapt resource value: 0x7f0900e0
-			public const int mr_picker_route_icon = 2131296480;
+			// aapt resource value: 0x7f0a00e0
+			public const int mr_picker_route_icon = 2131362016;
 			
-			// aapt resource value: 0x7f0900e1
-			public const int mr_picker_route_name = 2131296481;
+			// aapt resource value: 0x7f0a00e1
+			public const int mr_picker_route_name = 2131362017;
 			
-			// aapt resource value: 0x7f0900d6
-			public const int mr_playback_control = 2131296470;
+			// aapt resource value: 0x7f0a00d6
+			public const int mr_playback_control = 2131362006;
 			
-			// aapt resource value: 0x7f0900cf
-			public const int mr_title_bar = 2131296463;
+			// aapt resource value: 0x7f0a00cf
+			public const int mr_title_bar = 2131361999;
 			
-			// aapt resource value: 0x7f0900d8
-			public const int mr_volume_control = 2131296472;
+			// aapt resource value: 0x7f0a00d8
+			public const int mr_volume_control = 2131362008;
 			
-			// aapt resource value: 0x7f0900d9
-			public const int mr_volume_group_list = 2131296473;
+			// aapt resource value: 0x7f0a00d9
+			public const int mr_volume_group_list = 2131362009;
 			
-			// aapt resource value: 0x7f0900db
-			public const int mr_volume_item_icon = 2131296475;
+			// aapt resource value: 0x7f0a00db
+			public const int mr_volume_item_icon = 2131362011;
 			
-			// aapt resource value: 0x7f0900dc
-			public const int mr_volume_slider = 2131296476;
+			// aapt resource value: 0x7f0a00dc
+			public const int mr_volume_slider = 2131362012;
 			
-			// aapt resource value: 0x7f090014
-			public const int mtrl_child_content_container = 2131296276;
+			// aapt resource value: 0x7f0a0014
+			public const int mtrl_child_content_container = 2131361812;
 			
-			// aapt resource value: 0x7f090015
-			public const int mtrl_internal_children_alpha_tag = 2131296277;
+			// aapt resource value: 0x7f0a0015
+			public const int mtrl_internal_children_alpha_tag = 2131361813;
 			
-			// aapt resource value: 0x7f090031
-			public const int multiply = 2131296305;
+			// aapt resource value: 0x7f0a0031
+			public const int multiply = 2131361841;
 			
-			// aapt resource value: 0x7f0900ac
-			public const int navigation_header_container = 2131296428;
+			// aapt resource value: 0x7f0a00ac
+			public const int navigation_header_container = 2131361964;
 			
-			// aapt resource value: 0x7f090044
-			public const int never = 2131296324;
+			// aapt resource value: 0x7f0a0044
+			public const int never = 2131361860;
 			
-			// aapt resource value: 0x7f09002b
-			public const int none = 2131296299;
+			// aapt resource value: 0x7f0a002b
+			public const int none = 2131361835;
 			
-			// aapt resource value: 0x7f090027
-			public const int normal = 2131296295;
+			// aapt resource value: 0x7f0a0027
+			public const int normal = 2131361831;
 			
-			// aapt resource value: 0x7f0900f6
-			public const int notification_background = 2131296502;
+			// aapt resource value: 0x7f0a00f6
+			public const int notification_background = 2131362038;
 			
-			// aapt resource value: 0x7f0900f0
-			public const int notification_main_column = 2131296496;
+			// aapt resource value: 0x7f0a00f0
+			public const int notification_main_column = 2131362032;
 			
-			// aapt resource value: 0x7f0900ef
-			public const int notification_main_column_container = 2131296495;
+			// aapt resource value: 0x7f0a00ef
+			public const int notification_main_column_container = 2131362031;
 			
-			// aapt resource value: 0x7f090062
-			public const int outline = 2131296354;
+			// aapt resource value: 0x7f0a0062
+			public const int outline = 2131361890;
 			
-			// aapt resource value: 0x7f090059
-			public const int parallax = 2131296345;
+			// aapt resource value: 0x7f0a0059
+			public const int parallax = 2131361881;
 			
-			// aapt resource value: 0x7f090076
-			public const int parentPanel = 2131296374;
+			// aapt resource value: 0x7f0a0076
+			public const int parentPanel = 2131361910;
 			
-			// aapt resource value: 0x7f09000b
-			public const int parent_matrix = 2131296267;
+			// aapt resource value: 0x7f0a000b
+			public const int parent_matrix = 2131361803;
 			
-			// aapt resource value: 0x7f09005a
-			public const int pin = 2131296346;
+			// aapt resource value: 0x7f0a005a
+			public const int pin = 2131361882;
 			
-			// aapt resource value: 0x7f090006
-			public const int progress_circular = 2131296262;
+			// aapt resource value: 0x7f0a0006
+			public const int progress_circular = 2131361798;
 			
-			// aapt resource value: 0x7f090007
-			public const int progress_horizontal = 2131296263;
+			// aapt resource value: 0x7f0a0007
+			public const int progress_horizontal = 2131361799;
 			
-			// aapt resource value: 0x7f090089
-			public const int radio = 2131296393;
+			// aapt resource value: 0x7f0a0089
+			public const int radio = 2131361929;
 			
-			// aapt resource value: 0x7f090057
-			public const int right = 2131296343;
+			// aapt resource value: 0x7f0a0057
+			public const int right = 2131361879;
 			
-			// aapt resource value: 0x7f0900f5
-			public const int right_icon = 2131296501;
+			// aapt resource value: 0x7f0a00f5
+			public const int right_icon = 2131362037;
 			
-			// aapt resource value: 0x7f0900f1
-			public const int right_side = 2131296497;
+			// aapt resource value: 0x7f0a00f1
+			public const int right_side = 2131362033;
 			
-			// aapt resource value: 0x7f09000c
-			public const int save_image_matrix = 2131296268;
+			// aapt resource value: 0x7f0a000c
+			public const int save_image_matrix = 2131361804;
 			
-			// aapt resource value: 0x7f09000d
-			public const int save_non_transition_alpha = 2131296269;
+			// aapt resource value: 0x7f0a000d
+			public const int save_non_transition_alpha = 2131361805;
 			
-			// aapt resource value: 0x7f09000e
-			public const int save_scale_type = 2131296270;
+			// aapt resource value: 0x7f0a000e
+			public const int save_scale_type = 2131361806;
 			
-			// aapt resource value: 0x7f090032
-			public const int screen = 2131296306;
+			// aapt resource value: 0x7f0a0032
+			public const int screen = 2131361842;
 			
-			// aapt resource value: 0x7f09004b
-			public const int scroll = 2131296331;
+			// aapt resource value: 0x7f0a004b
+			public const int scroll = 2131361867;
 			
-			// aapt resource value: 0x7f09007c
-			public const int scrollIndicatorDown = 2131296380;
+			// aapt resource value: 0x7f0a007c
+			public const int scrollIndicatorDown = 2131361916;
 			
-			// aapt resource value: 0x7f090078
-			public const int scrollIndicatorUp = 2131296376;
+			// aapt resource value: 0x7f0a0078
+			public const int scrollIndicatorUp = 2131361912;
 			
-			// aapt resource value: 0x7f090079
-			public const int scrollView = 2131296377;
+			// aapt resource value: 0x7f0a0079
+			public const int scrollView = 2131361913;
 			
-			// aapt resource value: 0x7f09005f
-			public const int scrollable = 2131296351;
+			// aapt resource value: 0x7f0a005f
+			public const int scrollable = 2131361887;
 			
-			// aapt resource value: 0x7f090093
-			public const int search_badge = 2131296403;
+			// aapt resource value: 0x7f0a0093
+			public const int search_badge = 2131361939;
 			
-			// aapt resource value: 0x7f090092
-			public const int search_bar = 2131296402;
+			// aapt resource value: 0x7f0a0092
+			public const int search_bar = 2131361938;
 			
-			// aapt resource value: 0x7f090094
-			public const int search_button = 2131296404;
+			// aapt resource value: 0x7f0a0094
+			public const int search_button = 2131361940;
 			
-			// aapt resource value: 0x7f090099
-			public const int search_close_btn = 2131296409;
+			// aapt resource value: 0x7f0a0099
+			public const int search_close_btn = 2131361945;
 			
-			// aapt resource value: 0x7f090095
-			public const int search_edit_frame = 2131296405;
+			// aapt resource value: 0x7f0a0095
+			public const int search_edit_frame = 2131361941;
 			
-			// aapt resource value: 0x7f09009b
-			public const int search_go_btn = 2131296411;
+			// aapt resource value: 0x7f0a009b
+			public const int search_go_btn = 2131361947;
 			
-			// aapt resource value: 0x7f090096
-			public const int search_mag_icon = 2131296406;
+			// aapt resource value: 0x7f0a0096
+			public const int search_mag_icon = 2131361942;
 			
-			// aapt resource value: 0x7f090097
-			public const int search_plate = 2131296407;
+			// aapt resource value: 0x7f0a0097
+			public const int search_plate = 2131361943;
 			
-			// aapt resource value: 0x7f090098
-			public const int search_src_text = 2131296408;
+			// aapt resource value: 0x7f0a0098
+			public const int search_src_text = 2131361944;
 			
-			// aapt resource value: 0x7f09009c
-			public const int search_voice_btn = 2131296412;
+			// aapt resource value: 0x7f0a009c
+			public const int search_voice_btn = 2131361948;
 			
-			// aapt resource value: 0x7f09009d
-			public const int select_dialog_listview = 2131296413;
+			// aapt resource value: 0x7f0a009d
+			public const int select_dialog_listview = 2131361949;
 			
-			// aapt resource value: 0x7f090051
-			public const int selected = 2131296337;
+			// aapt resource value: 0x7f0a0051
+			public const int selected = 2131361873;
 			
-			// aapt resource value: 0x7f0900fe
-			public const int shellcontent_appbar = 2131296510;
+			// aapt resource value: 0x7f0a00fe
+			public const int shellcontent_appbar = 2131362046;
 			
-			// aapt resource value: 0x7f090100
-			public const int shellcontent_scrollview = 2131296512;
+			// aapt resource value: 0x7f0a00ff
+			public const int shellcontent_toolbar = 2131362047;
 			
-			// aapt resource value: 0x7f0900ff
-			public const int shellcontent_toolbar = 2131296511;
+			// aapt resource value: 0x7f0a0085
+			public const int shortcut = 2131361925;
 			
-			// aapt resource value: 0x7f090085
-			public const int shortcut = 2131296389;
+			// aapt resource value: 0x7f0a002c
+			public const int showCustom = 2131361836;
 			
-			// aapt resource value: 0x7f09002c
-			public const int showCustom = 2131296300;
+			// aapt resource value: 0x7f0a002d
+			public const int showHome = 2131361837;
 			
-			// aapt resource value: 0x7f09002d
-			public const int showHome = 2131296301;
+			// aapt resource value: 0x7f0a002e
+			public const int showTitle = 2131361838;
 			
-			// aapt resource value: 0x7f09002e
-			public const int showTitle = 2131296302;
+			// aapt resource value: 0x7f0a0100
+			public const int sliding_tabs = 2131362048;
 			
-			// aapt resource value: 0x7f090101
-			public const int sliding_tabs = 2131296513;
+			// aapt resource value: 0x7f0a00a6
+			public const int smallLabel = 2131361958;
 			
-			// aapt resource value: 0x7f0900a6
-			public const int smallLabel = 2131296422;
+			// aapt resource value: 0x7f0a0016
+			public const int snackbar_action = 2131361814;
 			
-			// aapt resource value: 0x7f090016
-			public const int snackbar_action = 2131296278;
+			// aapt resource value: 0x7f0a0017
+			public const int snackbar_text = 2131361815;
 			
-			// aapt resource value: 0x7f090017
-			public const int snackbar_text = 2131296279;
+			// aapt resource value: 0x7f0a004c
+			public const int snap = 2131361868;
 			
-			// aapt resource value: 0x7f09004c
-			public const int snap = 2131296332;
+			// aapt resource value: 0x7f0a004d
+			public const int snapMargins = 2131361869;
 			
-			// aapt resource value: 0x7f09004d
-			public const int snapMargins = 2131296333;
+			// aapt resource value: 0x7f0a0075
+			public const int spacer = 2131361909;
 			
-			// aapt resource value: 0x7f090075
-			public const int spacer = 2131296373;
+			// aapt resource value: 0x7f0a0008
+			public const int split_action_bar = 2131361800;
 			
-			// aapt resource value: 0x7f090008
-			public const int split_action_bar = 2131296264;
+			// aapt resource value: 0x7f0a0033
+			public const int src_atop = 2131361843;
 			
-			// aapt resource value: 0x7f090033
-			public const int src_atop = 2131296307;
+			// aapt resource value: 0x7f0a0034
+			public const int src_in = 2131361844;
 			
-			// aapt resource value: 0x7f090034
-			public const int src_in = 2131296308;
+			// aapt resource value: 0x7f0a0035
+			public const int src_over = 2131361845;
 			
-			// aapt resource value: 0x7f090035
-			public const int src_over = 2131296309;
+			// aapt resource value: 0x7f0a0058
+			public const int start = 2131361880;
 			
-			// aapt resource value: 0x7f090058
-			public const int start = 2131296344;
+			// aapt resource value: 0x7f0a00ec
+			public const int status_bar_latest_event_content = 2131362028;
 			
-			// aapt resource value: 0x7f0900ec
-			public const int status_bar_latest_event_content = 2131296492;
+			// aapt resource value: 0x7f0a005d
+			public const int stretch = 2131361885;
 			
-			// aapt resource value: 0x7f09005d
-			public const int stretch = 2131296349;
+			// aapt resource value: 0x7f0a0086
+			public const int submenuarrow = 2131361926;
 			
-			// aapt resource value: 0x7f090086
-			public const int submenuarrow = 2131296390;
+			// aapt resource value: 0x7f0a009a
+			public const int submit_area = 2131361946;
 			
-			// aapt resource value: 0x7f09009a
-			public const int submit_area = 2131296410;
+			// aapt resource value: 0x7f0a0028
+			public const int tabMode = 2131361832;
 			
-			// aapt resource value: 0x7f090028
-			public const int tabMode = 2131296296;
+			// aapt resource value: 0x7f0a001e
+			public const int tag_transition_group = 2131361822;
 			
-			// aapt resource value: 0x7f09001e
-			public const int tag_transition_group = 2131296286;
+			// aapt resource value: 0x7f0a001f
+			public const int tag_unhandled_key_event_manager = 2131361823;
 			
-			// aapt resource value: 0x7f09001f
-			public const int tag_unhandled_key_event_manager = 2131296287;
+			// aapt resource value: 0x7f0a0020
+			public const int tag_unhandled_key_listeners = 2131361824;
 			
-			// aapt resource value: 0x7f090020
-			public const int tag_unhandled_key_listeners = 2131296288;
+			// aapt resource value: 0x7f0a0021
+			public const int text = 2131361825;
 			
-			// aapt resource value: 0x7f090021
-			public const int text = 2131296289;
+			// aapt resource value: 0x7f0a0022
+			public const int text2 = 2131361826;
 			
-			// aapt resource value: 0x7f090022
-			public const int text2 = 2131296290;
+			// aapt resource value: 0x7f0a007b
+			public const int textSpacerNoButtons = 2131361915;
 			
-			// aapt resource value: 0x7f09007b
-			public const int textSpacerNoButtons = 2131296379;
+			// aapt resource value: 0x7f0a007a
+			public const int textSpacerNoTitle = 2131361914;
 			
-			// aapt resource value: 0x7f09007a
-			public const int textSpacerNoTitle = 2131296378;
+			// aapt resource value: 0x7f0a005c
+			public const int textStart = 2131361884;
 			
-			// aapt resource value: 0x7f09005c
-			public const int textStart = 2131296348;
+			// aapt resource value: 0x7f0a00b5
+			public const int textViewStatus = 2131361973;
 			
-			// aapt resource value: 0x7f0900b5
-			public const int textViewStatus = 2131296437;
+			// aapt resource value: 0x7f0a00b1
+			public const int text_input_password_toggle = 2131361969;
 			
-			// aapt resource value: 0x7f0900b1
-			public const int text_input_password_toggle = 2131296433;
+			// aapt resource value: 0x7f0a0018
+			public const int textinput_counter = 2131361816;
 			
-			// aapt resource value: 0x7f090018
-			public const int textinput_counter = 2131296280;
+			// aapt resource value: 0x7f0a0019
+			public const int textinput_error = 2131361817;
 			
-			// aapt resource value: 0x7f090019
-			public const int textinput_error = 2131296281;
+			// aapt resource value: 0x7f0a001a
+			public const int textinput_helper_text = 2131361818;
 			
-			// aapt resource value: 0x7f09001a
-			public const int textinput_helper_text = 2131296282;
+			// aapt resource value: 0x7f0a00f2
+			public const int time = 2131362034;
 			
-			// aapt resource value: 0x7f0900f2
-			public const int time = 2131296498;
+			// aapt resource value: 0x7f0a0023
+			public const int title = 2131361827;
 			
-			// aapt resource value: 0x7f090023
-			public const int title = 2131296291;
+			// aapt resource value: 0x7f0a0082
+			public const int titleDividerNoCustom = 2131361922;
 			
-			// aapt resource value: 0x7f090082
-			public const int titleDividerNoCustom = 2131296386;
+			// aapt resource value: 0x7f0a0080
+			public const int title_template = 2131361920;
 			
-			// aapt resource value: 0x7f090080
-			public const int title_template = 2131296384;
+			// aapt resource value: 0x7f0a0101
+			public const int toolbar = 2131362049;
 			
-			// aapt resource value: 0x7f090102
-			public const int toolbar = 2131296514;
+			// aapt resource value: 0x7f0a0047
+			public const int top = 2131361863;
 			
-			// aapt resource value: 0x7f090047
-			public const int top = 2131296327;
+			// aapt resource value: 0x7f0a007f
+			public const int topPanel = 2131361919;
 			
-			// aapt resource value: 0x7f09007f
-			public const int topPanel = 2131296383;
+			// aapt resource value: 0x7f0a00aa
+			public const int touch_outside = 2131361962;
 			
-			// aapt resource value: 0x7f0900aa
-			public const int touch_outside = 2131296426;
+			// aapt resource value: 0x7f0a000f
+			public const int transition_current_scene = 2131361807;
 			
-			// aapt resource value: 0x7f09000f
-			public const int transition_current_scene = 2131296271;
+			// aapt resource value: 0x7f0a0010
+			public const int transition_layout_save = 2131361808;
 			
-			// aapt resource value: 0x7f090010
-			public const int transition_layout_save = 2131296272;
+			// aapt resource value: 0x7f0a0011
+			public const int transition_position = 2131361809;
 			
-			// aapt resource value: 0x7f090011
-			public const int transition_position = 2131296273;
+			// aapt resource value: 0x7f0a0012
+			public const int transition_scene_layoutid_cache = 2131361810;
 			
-			// aapt resource value: 0x7f090012
-			public const int transition_scene_layoutid_cache = 2131296274;
+			// aapt resource value: 0x7f0a0013
+			public const int transition_transform = 2131361811;
 			
-			// aapt resource value: 0x7f090013
-			public const int transition_transform = 2131296275;
+			// aapt resource value: 0x7f0a0036
+			public const int uniform = 2131361846;
 			
-			// aapt resource value: 0x7f090036
-			public const int uniform = 2131296310;
+			// aapt resource value: 0x7f0a0052
+			public const int unlabeled = 2131361874;
 			
-			// aapt resource value: 0x7f090052
-			public const int unlabeled = 2131296338;
+			// aapt resource value: 0x7f0a0009
+			public const int up = 2131361801;
 			
-			// aapt resource value: 0x7f090009
-			public const int up = 2131296265;
+			// aapt resource value: 0x7f0a002f
+			public const int useLogo = 2131361839;
 			
-			// aapt resource value: 0x7f09002f
-			public const int useLogo = 2131296303;
+			// aapt resource value: 0x7f0a001b
+			public const int view_offset_helper = 2131361819;
 			
-			// aapt resource value: 0x7f09001b
-			public const int view_offset_helper = 2131296283;
+			// aapt resource value: 0x7f0a0102
+			public const int visible = 2131362050;
 			
-			// aapt resource value: 0x7f090103
-			public const int visible = 2131296515;
+			// aapt resource value: 0x7f0a00da
+			public const int volume_item_container = 2131362010;
 			
-			// aapt resource value: 0x7f0900da
-			public const int volume_item_container = 2131296474;
+			// aapt resource value: 0x7f0a0045
+			public const int withText = 2131361861;
 			
-			// aapt resource value: 0x7f090045
-			public const int withText = 2131296325;
-			
-			// aapt resource value: 0x7f090037
-			public const int wrap_content = 2131296311;
+			// aapt resource value: 0x7f0a0037
+			public const int wrap_content = 2131361847;
 			
 			static Id()
 			{
@@ -12310,62 +12307,62 @@ namespace BLE.Client.Droid
 		public partial class Integer
 		{
 			
-			// aapt resource value: 0x7f0b0004
-			public const int abc_config_activityDefaultDur = 2131427332;
+			// aapt resource value: 0x7f0c0004
+			public const int abc_config_activityDefaultDur = 2131492868;
 			
-			// aapt resource value: 0x7f0b0005
-			public const int abc_config_activityShortDur = 2131427333;
+			// aapt resource value: 0x7f0c0005
+			public const int abc_config_activityShortDur = 2131492869;
 			
-			// aapt resource value: 0x7f0b0009
-			public const int app_bar_elevation_anim_duration = 2131427337;
+			// aapt resource value: 0x7f0c0009
+			public const int app_bar_elevation_anim_duration = 2131492873;
 			
-			// aapt resource value: 0x7f0b000a
-			public const int bottom_sheet_slide_duration = 2131427338;
+			// aapt resource value: 0x7f0c000a
+			public const int bottom_sheet_slide_duration = 2131492874;
 			
-			// aapt resource value: 0x7f0b0006
-			public const int cancel_button_image_alpha = 2131427334;
+			// aapt resource value: 0x7f0c0006
+			public const int cancel_button_image_alpha = 2131492870;
 			
-			// aapt resource value: 0x7f0b0007
-			public const int config_tooltipAnimTime = 2131427335;
+			// aapt resource value: 0x7f0c0007
+			public const int config_tooltipAnimTime = 2131492871;
 			
-			// aapt resource value: 0x7f0b0008
-			public const int design_snackbar_text_max_lines = 2131427336;
+			// aapt resource value: 0x7f0c0008
+			public const int design_snackbar_text_max_lines = 2131492872;
 			
-			// aapt resource value: 0x7f0b000b
-			public const int design_tab_indicator_anim_duration_ms = 2131427339;
+			// aapt resource value: 0x7f0c000b
+			public const int design_tab_indicator_anim_duration_ms = 2131492875;
 			
-			// aapt resource value: 0x7f0b000c
-			public const int hide_password_duration = 2131427340;
+			// aapt resource value: 0x7f0c000c
+			public const int hide_password_duration = 2131492876;
 			
-			// aapt resource value: 0x7f0b0000
-			public const int mr_controller_volume_group_list_animation_duration_ms = 2131427328;
+			// aapt resource value: 0x7f0c0000
+			public const int mr_controller_volume_group_list_animation_duration_ms = 2131492864;
 			
-			// aapt resource value: 0x7f0b0001
-			public const int mr_controller_volume_group_list_fade_in_duration_ms = 2131427329;
+			// aapt resource value: 0x7f0c0001
+			public const int mr_controller_volume_group_list_fade_in_duration_ms = 2131492865;
 			
-			// aapt resource value: 0x7f0b0002
-			public const int mr_controller_volume_group_list_fade_out_duration_ms = 2131427330;
+			// aapt resource value: 0x7f0c0002
+			public const int mr_controller_volume_group_list_fade_out_duration_ms = 2131492866;
 			
-			// aapt resource value: 0x7f0b0003
-			public const int mr_update_routes_delay_ms = 2131427331;
+			// aapt resource value: 0x7f0c0003
+			public const int mr_update_routes_delay_ms = 2131492867;
 			
-			// aapt resource value: 0x7f0b000d
-			public const int mtrl_btn_anim_delay_ms = 2131427341;
+			// aapt resource value: 0x7f0c000d
+			public const int mtrl_btn_anim_delay_ms = 2131492877;
 			
-			// aapt resource value: 0x7f0b000e
-			public const int mtrl_btn_anim_duration_ms = 2131427342;
+			// aapt resource value: 0x7f0c000e
+			public const int mtrl_btn_anim_duration_ms = 2131492878;
 			
-			// aapt resource value: 0x7f0b000f
-			public const int mtrl_chip_anim_duration = 2131427343;
+			// aapt resource value: 0x7f0c000f
+			public const int mtrl_chip_anim_duration = 2131492879;
 			
-			// aapt resource value: 0x7f0b0010
-			public const int mtrl_tab_indicator_anim_duration_ms = 2131427344;
+			// aapt resource value: 0x7f0c0010
+			public const int mtrl_tab_indicator_anim_duration_ms = 2131492880;
 			
-			// aapt resource value: 0x7f0b0011
-			public const int show_password_duration = 2131427345;
+			// aapt resource value: 0x7f0c0011
+			public const int show_password_duration = 2131492881;
 			
-			// aapt resource value: 0x7f0b0012
-			public const int status_bar_notification_info_maxnum = 2131427346;
+			// aapt resource value: 0x7f0c0012
+			public const int status_bar_notification_info_maxnum = 2131492882;
 			
 			static Integer()
 			{
@@ -12691,248 +12688,248 @@ namespace BLE.Client.Droid
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f0a0018
-			public const int abc_action_bar_home_description = 2131361816;
+			// aapt resource value: 0x7f0b0018
+			public const int abc_action_bar_home_description = 2131427352;
 			
-			// aapt resource value: 0x7f0a0019
-			public const int abc_action_bar_up_description = 2131361817;
+			// aapt resource value: 0x7f0b0019
+			public const int abc_action_bar_up_description = 2131427353;
 			
-			// aapt resource value: 0x7f0a001a
-			public const int abc_action_menu_overflow_description = 2131361818;
+			// aapt resource value: 0x7f0b001a
+			public const int abc_action_menu_overflow_description = 2131427354;
 			
-			// aapt resource value: 0x7f0a001b
-			public const int abc_action_mode_done = 2131361819;
+			// aapt resource value: 0x7f0b001b
+			public const int abc_action_mode_done = 2131427355;
 			
-			// aapt resource value: 0x7f0a001c
-			public const int abc_activity_chooser_view_see_all = 2131361820;
+			// aapt resource value: 0x7f0b001c
+			public const int abc_activity_chooser_view_see_all = 2131427356;
 			
-			// aapt resource value: 0x7f0a001d
-			public const int abc_activitychooserview_choose_application = 2131361821;
+			// aapt resource value: 0x7f0b001d
+			public const int abc_activitychooserview_choose_application = 2131427357;
 			
-			// aapt resource value: 0x7f0a001e
-			public const int abc_capital_off = 2131361822;
+			// aapt resource value: 0x7f0b001e
+			public const int abc_capital_off = 2131427358;
 			
-			// aapt resource value: 0x7f0a001f
-			public const int abc_capital_on = 2131361823;
+			// aapt resource value: 0x7f0b001f
+			public const int abc_capital_on = 2131427359;
 			
-			// aapt resource value: 0x7f0a0034
-			public const int abc_font_family_body_1_material = 2131361844;
+			// aapt resource value: 0x7f0b0034
+			public const int abc_font_family_body_1_material = 2131427380;
 			
-			// aapt resource value: 0x7f0a0035
-			public const int abc_font_family_body_2_material = 2131361845;
+			// aapt resource value: 0x7f0b0035
+			public const int abc_font_family_body_2_material = 2131427381;
 			
-			// aapt resource value: 0x7f0a0036
-			public const int abc_font_family_button_material = 2131361846;
+			// aapt resource value: 0x7f0b0036
+			public const int abc_font_family_button_material = 2131427382;
 			
-			// aapt resource value: 0x7f0a0037
-			public const int abc_font_family_caption_material = 2131361847;
+			// aapt resource value: 0x7f0b0037
+			public const int abc_font_family_caption_material = 2131427383;
 			
-			// aapt resource value: 0x7f0a0038
-			public const int abc_font_family_display_1_material = 2131361848;
+			// aapt resource value: 0x7f0b0038
+			public const int abc_font_family_display_1_material = 2131427384;
 			
-			// aapt resource value: 0x7f0a0039
-			public const int abc_font_family_display_2_material = 2131361849;
+			// aapt resource value: 0x7f0b0039
+			public const int abc_font_family_display_2_material = 2131427385;
 			
-			// aapt resource value: 0x7f0a003a
-			public const int abc_font_family_display_3_material = 2131361850;
+			// aapt resource value: 0x7f0b003a
+			public const int abc_font_family_display_3_material = 2131427386;
 			
-			// aapt resource value: 0x7f0a003b
-			public const int abc_font_family_display_4_material = 2131361851;
+			// aapt resource value: 0x7f0b003b
+			public const int abc_font_family_display_4_material = 2131427387;
 			
-			// aapt resource value: 0x7f0a003c
-			public const int abc_font_family_headline_material = 2131361852;
+			// aapt resource value: 0x7f0b003c
+			public const int abc_font_family_headline_material = 2131427388;
 			
-			// aapt resource value: 0x7f0a003d
-			public const int abc_font_family_menu_material = 2131361853;
+			// aapt resource value: 0x7f0b003d
+			public const int abc_font_family_menu_material = 2131427389;
 			
-			// aapt resource value: 0x7f0a003e
-			public const int abc_font_family_subhead_material = 2131361854;
+			// aapt resource value: 0x7f0b003e
+			public const int abc_font_family_subhead_material = 2131427390;
 			
-			// aapt resource value: 0x7f0a003f
-			public const int abc_font_family_title_material = 2131361855;
+			// aapt resource value: 0x7f0b003f
+			public const int abc_font_family_title_material = 2131427391;
 			
-			// aapt resource value: 0x7f0a0020
-			public const int abc_menu_alt_shortcut_label = 2131361824;
+			// aapt resource value: 0x7f0b0020
+			public const int abc_menu_alt_shortcut_label = 2131427360;
 			
-			// aapt resource value: 0x7f0a0021
-			public const int abc_menu_ctrl_shortcut_label = 2131361825;
+			// aapt resource value: 0x7f0b0021
+			public const int abc_menu_ctrl_shortcut_label = 2131427361;
 			
-			// aapt resource value: 0x7f0a0022
-			public const int abc_menu_delete_shortcut_label = 2131361826;
+			// aapt resource value: 0x7f0b0022
+			public const int abc_menu_delete_shortcut_label = 2131427362;
 			
-			// aapt resource value: 0x7f0a0023
-			public const int abc_menu_enter_shortcut_label = 2131361827;
+			// aapt resource value: 0x7f0b0023
+			public const int abc_menu_enter_shortcut_label = 2131427363;
 			
-			// aapt resource value: 0x7f0a0024
-			public const int abc_menu_function_shortcut_label = 2131361828;
+			// aapt resource value: 0x7f0b0024
+			public const int abc_menu_function_shortcut_label = 2131427364;
 			
-			// aapt resource value: 0x7f0a0025
-			public const int abc_menu_meta_shortcut_label = 2131361829;
+			// aapt resource value: 0x7f0b0025
+			public const int abc_menu_meta_shortcut_label = 2131427365;
 			
-			// aapt resource value: 0x7f0a0026
-			public const int abc_menu_shift_shortcut_label = 2131361830;
+			// aapt resource value: 0x7f0b0026
+			public const int abc_menu_shift_shortcut_label = 2131427366;
 			
-			// aapt resource value: 0x7f0a0027
-			public const int abc_menu_space_shortcut_label = 2131361831;
+			// aapt resource value: 0x7f0b0027
+			public const int abc_menu_space_shortcut_label = 2131427367;
 			
-			// aapt resource value: 0x7f0a0028
-			public const int abc_menu_sym_shortcut_label = 2131361832;
+			// aapt resource value: 0x7f0b0028
+			public const int abc_menu_sym_shortcut_label = 2131427368;
 			
-			// aapt resource value: 0x7f0a0029
-			public const int abc_prepend_shortcut_label = 2131361833;
+			// aapt resource value: 0x7f0b0029
+			public const int abc_prepend_shortcut_label = 2131427369;
 			
-			// aapt resource value: 0x7f0a002a
-			public const int abc_search_hint = 2131361834;
+			// aapt resource value: 0x7f0b002a
+			public const int abc_search_hint = 2131427370;
 			
-			// aapt resource value: 0x7f0a002b
-			public const int abc_searchview_description_clear = 2131361835;
+			// aapt resource value: 0x7f0b002b
+			public const int abc_searchview_description_clear = 2131427371;
 			
-			// aapt resource value: 0x7f0a002c
-			public const int abc_searchview_description_query = 2131361836;
+			// aapt resource value: 0x7f0b002c
+			public const int abc_searchview_description_query = 2131427372;
 			
-			// aapt resource value: 0x7f0a002d
-			public const int abc_searchview_description_search = 2131361837;
+			// aapt resource value: 0x7f0b002d
+			public const int abc_searchview_description_search = 2131427373;
 			
-			// aapt resource value: 0x7f0a002e
-			public const int abc_searchview_description_submit = 2131361838;
+			// aapt resource value: 0x7f0b002e
+			public const int abc_searchview_description_submit = 2131427374;
 			
-			// aapt resource value: 0x7f0a002f
-			public const int abc_searchview_description_voice = 2131361839;
+			// aapt resource value: 0x7f0b002f
+			public const int abc_searchview_description_voice = 2131427375;
 			
-			// aapt resource value: 0x7f0a0030
-			public const int abc_shareactionprovider_share_with = 2131361840;
+			// aapt resource value: 0x7f0b0030
+			public const int abc_shareactionprovider_share_with = 2131427376;
 			
-			// aapt resource value: 0x7f0a0031
-			public const int abc_shareactionprovider_share_with_application = 2131361841;
+			// aapt resource value: 0x7f0b0031
+			public const int abc_shareactionprovider_share_with_application = 2131427377;
 			
-			// aapt resource value: 0x7f0a0032
-			public const int abc_toolbar_collapse_description = 2131361842;
+			// aapt resource value: 0x7f0b0032
+			public const int abc_toolbar_collapse_description = 2131427378;
 			
-			// aapt resource value: 0x7f0a0040
-			public const int appbar_scrolling_view_behavior = 2131361856;
+			// aapt resource value: 0x7f0b0040
+			public const int appbar_scrolling_view_behavior = 2131427392;
 			
-			// aapt resource value: 0x7f0a0041
-			public const int bottom_sheet_behavior = 2131361857;
+			// aapt resource value: 0x7f0b0041
+			public const int bottom_sheet_behavior = 2131427393;
 			
-			// aapt resource value: 0x7f0a0042
-			public const int character_counter_content_description = 2131361858;
+			// aapt resource value: 0x7f0b0042
+			public const int character_counter_content_description = 2131427394;
 			
-			// aapt resource value: 0x7f0a0043
-			public const int character_counter_pattern = 2131361859;
+			// aapt resource value: 0x7f0b0043
+			public const int character_counter_pattern = 2131427395;
 			
-			// aapt resource value: 0x7f0a004e
-			public const int fab_scroll_shrink_grow_autohide_behavior = 2131361870;
+			// aapt resource value: 0x7f0b004e
+			public const int fab_scroll_shrink_grow_autohide_behavior = 2131427406;
 			
-			// aapt resource value: 0x7f0a0044
-			public const int fab_transformation_scrim_behavior = 2131361860;
+			// aapt resource value: 0x7f0b0044
+			public const int fab_transformation_scrim_behavior = 2131427396;
 			
-			// aapt resource value: 0x7f0a0045
-			public const int fab_transformation_sheet_behavior = 2131361861;
+			// aapt resource value: 0x7f0b0045
+			public const int fab_transformation_sheet_behavior = 2131427397;
 			
-			// aapt resource value: 0x7f0a0046
-			public const int hide_bottom_view_on_scroll_behavior = 2131361862;
+			// aapt resource value: 0x7f0b0046
+			public const int hide_bottom_view_on_scroll_behavior = 2131427398;
 			
-			// aapt resource value: 0x7f0a0050
-			public const int library_name = 2131361872;
+			// aapt resource value: 0x7f0b0050
+			public const int library_name = 2131427408;
 			
-			// aapt resource value: 0x7f0a0000
-			public const int mr_button_content_description = 2131361792;
+			// aapt resource value: 0x7f0b0000
+			public const int mr_button_content_description = 2131427328;
 			
-			// aapt resource value: 0x7f0a0001
-			public const int mr_cast_button_connected = 2131361793;
+			// aapt resource value: 0x7f0b0001
+			public const int mr_cast_button_connected = 2131427329;
 			
-			// aapt resource value: 0x7f0a0002
-			public const int mr_cast_button_connecting = 2131361794;
+			// aapt resource value: 0x7f0b0002
+			public const int mr_cast_button_connecting = 2131427330;
 			
-			// aapt resource value: 0x7f0a0003
-			public const int mr_cast_button_disconnected = 2131361795;
+			// aapt resource value: 0x7f0b0003
+			public const int mr_cast_button_disconnected = 2131427331;
 			
-			// aapt resource value: 0x7f0a0015
-			public const int mr_cast_dialog_title_view_placeholder = 2131361813;
+			// aapt resource value: 0x7f0b0015
+			public const int mr_cast_dialog_title_view_placeholder = 2131427349;
 			
-			// aapt resource value: 0x7f0a0004
-			public const int mr_chooser_searching = 2131361796;
+			// aapt resource value: 0x7f0b0004
+			public const int mr_chooser_searching = 2131427332;
 			
-			// aapt resource value: 0x7f0a0005
-			public const int mr_chooser_title = 2131361797;
+			// aapt resource value: 0x7f0b0005
+			public const int mr_chooser_title = 2131427333;
 			
-			// aapt resource value: 0x7f0a0006
-			public const int mr_controller_album_art = 2131361798;
+			// aapt resource value: 0x7f0b0006
+			public const int mr_controller_album_art = 2131427334;
 			
-			// aapt resource value: 0x7f0a0007
-			public const int mr_controller_casting_screen = 2131361799;
+			// aapt resource value: 0x7f0b0007
+			public const int mr_controller_casting_screen = 2131427335;
 			
-			// aapt resource value: 0x7f0a0008
-			public const int mr_controller_close_description = 2131361800;
+			// aapt resource value: 0x7f0b0008
+			public const int mr_controller_close_description = 2131427336;
 			
-			// aapt resource value: 0x7f0a0009
-			public const int mr_controller_collapse_group = 2131361801;
+			// aapt resource value: 0x7f0b0009
+			public const int mr_controller_collapse_group = 2131427337;
 			
-			// aapt resource value: 0x7f0a000a
-			public const int mr_controller_disconnect = 2131361802;
+			// aapt resource value: 0x7f0b000a
+			public const int mr_controller_disconnect = 2131427338;
 			
-			// aapt resource value: 0x7f0a000b
-			public const int mr_controller_expand_group = 2131361803;
+			// aapt resource value: 0x7f0b000b
+			public const int mr_controller_expand_group = 2131427339;
 			
-			// aapt resource value: 0x7f0a000c
-			public const int mr_controller_no_info_available = 2131361804;
+			// aapt resource value: 0x7f0b000c
+			public const int mr_controller_no_info_available = 2131427340;
 			
-			// aapt resource value: 0x7f0a000d
-			public const int mr_controller_no_media_selected = 2131361805;
+			// aapt resource value: 0x7f0b000d
+			public const int mr_controller_no_media_selected = 2131427341;
 			
-			// aapt resource value: 0x7f0a000e
-			public const int mr_controller_pause = 2131361806;
+			// aapt resource value: 0x7f0b000e
+			public const int mr_controller_pause = 2131427342;
 			
-			// aapt resource value: 0x7f0a000f
-			public const int mr_controller_play = 2131361807;
+			// aapt resource value: 0x7f0b000f
+			public const int mr_controller_play = 2131427343;
 			
-			// aapt resource value: 0x7f0a0010
-			public const int mr_controller_stop = 2131361808;
+			// aapt resource value: 0x7f0b0010
+			public const int mr_controller_stop = 2131427344;
 			
-			// aapt resource value: 0x7f0a0011
-			public const int mr_controller_stop_casting = 2131361809;
+			// aapt resource value: 0x7f0b0011
+			public const int mr_controller_stop_casting = 2131427345;
 			
-			// aapt resource value: 0x7f0a0012
-			public const int mr_controller_volume_slider = 2131361810;
+			// aapt resource value: 0x7f0b0012
+			public const int mr_controller_volume_slider = 2131427346;
 			
-			// aapt resource value: 0x7f0a0016
-			public const int mr_dialog_device_header = 2131361814;
+			// aapt resource value: 0x7f0b0016
+			public const int mr_dialog_device_header = 2131427350;
 			
-			// aapt resource value: 0x7f0a0017
-			public const int mr_dialog_route_header = 2131361815;
+			// aapt resource value: 0x7f0b0017
+			public const int mr_dialog_route_header = 2131427351;
 			
-			// aapt resource value: 0x7f0a0013
-			public const int mr_system_route_name = 2131361811;
+			// aapt resource value: 0x7f0b0013
+			public const int mr_system_route_name = 2131427347;
 			
-			// aapt resource value: 0x7f0a0014
-			public const int mr_user_route_category_name = 2131361812;
+			// aapt resource value: 0x7f0b0014
+			public const int mr_user_route_category_name = 2131427348;
 			
-			// aapt resource value: 0x7f0a0047
-			public const int mtrl_chip_close_icon_content_description = 2131361863;
+			// aapt resource value: 0x7f0b0047
+			public const int mtrl_chip_close_icon_content_description = 2131427399;
 			
-			// aapt resource value: 0x7f0a0048
-			public const int password_toggle_content_description = 2131361864;
+			// aapt resource value: 0x7f0b0048
+			public const int password_toggle_content_description = 2131427400;
 			
-			// aapt resource value: 0x7f0a0049
-			public const int path_password_eye = 2131361865;
+			// aapt resource value: 0x7f0b0049
+			public const int path_password_eye = 2131427401;
 			
-			// aapt resource value: 0x7f0a004a
-			public const int path_password_eye_mask_strike_through = 2131361866;
+			// aapt resource value: 0x7f0b004a
+			public const int path_password_eye_mask_strike_through = 2131427402;
 			
-			// aapt resource value: 0x7f0a004b
-			public const int path_password_eye_mask_visible = 2131361867;
+			// aapt resource value: 0x7f0b004b
+			public const int path_password_eye_mask_visible = 2131427403;
 			
-			// aapt resource value: 0x7f0a004c
-			public const int path_password_strike_through = 2131361868;
+			// aapt resource value: 0x7f0b004c
+			public const int path_password_strike_through = 2131427404;
 			
-			// aapt resource value: 0x7f0a0033
-			public const int search_menu_title = 2131361843;
+			// aapt resource value: 0x7f0b0033
+			public const int search_menu_title = 2131427379;
 			
-			// aapt resource value: 0x7f0a004d
-			public const int status_bar_notification_info_overflow = 2131361869;
+			// aapt resource value: 0x7f0b004d
+			public const int status_bar_notification_info_overflow = 2131427405;
 			
-			// aapt resource value: 0x7f0a004f
-			public const int view_scroll_translation_autohide_behavior = 2131361871;
+			// aapt resource value: 0x7f0b004f
+			public const int view_scroll_translation_autohide_behavior = 2131427407;
 			
 			static String()
 			{
@@ -12947,1547 +12944,1550 @@ namespace BLE.Client.Droid
 		public partial class Style
 		{
 			
-			// aapt resource value: 0x7f0c0098
-			public const int AlertDialog_AppCompat = 2131493016;
+			// aapt resource value: 0x7f080099
+			public const int AlertDialog_AppCompat = 2131230873;
 			
-			// aapt resource value: 0x7f0c0099
-			public const int AlertDialog_AppCompat_Light = 2131493017;
+			// aapt resource value: 0x7f08009a
+			public const int AlertDialog_AppCompat_Light = 2131230874;
 			
-			// aapt resource value: 0x7f0c009a
-			public const int Animation_AppCompat_Dialog = 2131493018;
+			// aapt resource value: 0x7f08009b
+			public const int Animation_AppCompat_Dialog = 2131230875;
 			
-			// aapt resource value: 0x7f0c009b
-			public const int Animation_AppCompat_DropDownUp = 2131493019;
+			// aapt resource value: 0x7f08009c
+			public const int Animation_AppCompat_DropDownUp = 2131230876;
 			
-			// aapt resource value: 0x7f0c009c
-			public const int Animation_AppCompat_Tooltip = 2131493020;
+			// aapt resource value: 0x7f08009d
+			public const int Animation_AppCompat_Tooltip = 2131230877;
 			
-			// aapt resource value: 0x7f0c016d
-			public const int Animation_Design_BottomSheetDialog = 2131493229;
+			// aapt resource value: 0x7f08016e
+			public const int Animation_Design_BottomSheetDialog = 2131231086;
 			
-			// aapt resource value: 0x7f0c009d
-			public const int Base_AlertDialog_AppCompat = 2131493021;
+			// aapt resource value: 0x7f08009e
+			public const int Base_AlertDialog_AppCompat = 2131230878;
 			
-			// aapt resource value: 0x7f0c009e
-			public const int Base_AlertDialog_AppCompat_Light = 2131493022;
+			// aapt resource value: 0x7f08009f
+			public const int Base_AlertDialog_AppCompat_Light = 2131230879;
 			
-			// aapt resource value: 0x7f0c009f
-			public const int Base_Animation_AppCompat_Dialog = 2131493023;
+			// aapt resource value: 0x7f0800a0
+			public const int Base_Animation_AppCompat_Dialog = 2131230880;
 			
-			// aapt resource value: 0x7f0c00a0
-			public const int Base_Animation_AppCompat_DropDownUp = 2131493024;
+			// aapt resource value: 0x7f0800a1
+			public const int Base_Animation_AppCompat_DropDownUp = 2131230881;
 			
-			// aapt resource value: 0x7f0c00a1
-			public const int Base_Animation_AppCompat_Tooltip = 2131493025;
+			// aapt resource value: 0x7f0800a2
+			public const int Base_Animation_AppCompat_Tooltip = 2131230882;
 			
-			// aapt resource value: 0x7f0c000c
-			public const int Base_CardView = 2131492876;
+			// aapt resource value: 0x7f08000d
+			public const int Base_CardView = 2131230733;
 			
-			// aapt resource value: 0x7f0c00a2
-			public const int Base_DialogWindowTitle_AppCompat = 2131493026;
+			// aapt resource value: 0x7f0800a3
+			public const int Base_DialogWindowTitle_AppCompat = 2131230883;
 			
-			// aapt resource value: 0x7f0c00a3
-			public const int Base_DialogWindowTitleBackground_AppCompat = 2131493027;
+			// aapt resource value: 0x7f0800a4
+			public const int Base_DialogWindowTitleBackground_AppCompat = 2131230884;
 			
-			// aapt resource value: 0x7f0c002c
-			public const int Base_TextAppearance_AppCompat = 2131492908;
+			// aapt resource value: 0x7f08002d
+			public const int Base_TextAppearance_AppCompat = 2131230765;
 			
-			// aapt resource value: 0x7f0c002d
-			public const int Base_TextAppearance_AppCompat_Body1 = 2131492909;
+			// aapt resource value: 0x7f08002e
+			public const int Base_TextAppearance_AppCompat_Body1 = 2131230766;
 			
-			// aapt resource value: 0x7f0c002e
-			public const int Base_TextAppearance_AppCompat_Body2 = 2131492910;
+			// aapt resource value: 0x7f08002f
+			public const int Base_TextAppearance_AppCompat_Body2 = 2131230767;
 			
-			// aapt resource value: 0x7f0c002f
-			public const int Base_TextAppearance_AppCompat_Button = 2131492911;
+			// aapt resource value: 0x7f080030
+			public const int Base_TextAppearance_AppCompat_Button = 2131230768;
 			
-			// aapt resource value: 0x7f0c0030
-			public const int Base_TextAppearance_AppCompat_Caption = 2131492912;
+			// aapt resource value: 0x7f080031
+			public const int Base_TextAppearance_AppCompat_Caption = 2131230769;
 			
-			// aapt resource value: 0x7f0c0031
-			public const int Base_TextAppearance_AppCompat_Display1 = 2131492913;
+			// aapt resource value: 0x7f080032
+			public const int Base_TextAppearance_AppCompat_Display1 = 2131230770;
 			
-			// aapt resource value: 0x7f0c0032
-			public const int Base_TextAppearance_AppCompat_Display2 = 2131492914;
+			// aapt resource value: 0x7f080033
+			public const int Base_TextAppearance_AppCompat_Display2 = 2131230771;
 			
-			// aapt resource value: 0x7f0c0033
-			public const int Base_TextAppearance_AppCompat_Display3 = 2131492915;
+			// aapt resource value: 0x7f080034
+			public const int Base_TextAppearance_AppCompat_Display3 = 2131230772;
 			
-			// aapt resource value: 0x7f0c0034
-			public const int Base_TextAppearance_AppCompat_Display4 = 2131492916;
+			// aapt resource value: 0x7f080035
+			public const int Base_TextAppearance_AppCompat_Display4 = 2131230773;
 			
-			// aapt resource value: 0x7f0c0035
-			public const int Base_TextAppearance_AppCompat_Headline = 2131492917;
+			// aapt resource value: 0x7f080036
+			public const int Base_TextAppearance_AppCompat_Headline = 2131230774;
 			
-			// aapt resource value: 0x7f0c0036
-			public const int Base_TextAppearance_AppCompat_Inverse = 2131492918;
+			// aapt resource value: 0x7f080037
+			public const int Base_TextAppearance_AppCompat_Inverse = 2131230775;
 			
-			// aapt resource value: 0x7f0c0037
-			public const int Base_TextAppearance_AppCompat_Large = 2131492919;
+			// aapt resource value: 0x7f080038
+			public const int Base_TextAppearance_AppCompat_Large = 2131230776;
 			
-			// aapt resource value: 0x7f0c0038
-			public const int Base_TextAppearance_AppCompat_Large_Inverse = 2131492920;
+			// aapt resource value: 0x7f080039
+			public const int Base_TextAppearance_AppCompat_Large_Inverse = 2131230777;
 			
-			// aapt resource value: 0x7f0c0039
-			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131492921;
+			// aapt resource value: 0x7f08003a
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131230778;
 			
-			// aapt resource value: 0x7f0c003a
-			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131492922;
+			// aapt resource value: 0x7f08003b
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131230779;
 			
-			// aapt resource value: 0x7f0c003b
-			public const int Base_TextAppearance_AppCompat_Medium = 2131492923;
+			// aapt resource value: 0x7f08003c
+			public const int Base_TextAppearance_AppCompat_Medium = 2131230780;
 			
-			// aapt resource value: 0x7f0c003c
-			public const int Base_TextAppearance_AppCompat_Medium_Inverse = 2131492924;
+			// aapt resource value: 0x7f08003d
+			public const int Base_TextAppearance_AppCompat_Medium_Inverse = 2131230781;
 			
-			// aapt resource value: 0x7f0c003d
-			public const int Base_TextAppearance_AppCompat_Menu = 2131492925;
+			// aapt resource value: 0x7f08003e
+			public const int Base_TextAppearance_AppCompat_Menu = 2131230782;
 			
-			// aapt resource value: 0x7f0c00a4
-			public const int Base_TextAppearance_AppCompat_SearchResult = 2131493028;
+			// aapt resource value: 0x7f0800a5
+			public const int Base_TextAppearance_AppCompat_SearchResult = 2131230885;
 			
-			// aapt resource value: 0x7f0c003e
-			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131492926;
+			// aapt resource value: 0x7f08003f
+			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131230783;
 			
-			// aapt resource value: 0x7f0c003f
-			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131492927;
+			// aapt resource value: 0x7f080040
+			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131230784;
 			
-			// aapt resource value: 0x7f0c0040
-			public const int Base_TextAppearance_AppCompat_Small = 2131492928;
+			// aapt resource value: 0x7f080041
+			public const int Base_TextAppearance_AppCompat_Small = 2131230785;
 			
-			// aapt resource value: 0x7f0c0041
-			public const int Base_TextAppearance_AppCompat_Small_Inverse = 2131492929;
+			// aapt resource value: 0x7f080042
+			public const int Base_TextAppearance_AppCompat_Small_Inverse = 2131230786;
 			
-			// aapt resource value: 0x7f0c0042
-			public const int Base_TextAppearance_AppCompat_Subhead = 2131492930;
+			// aapt resource value: 0x7f080043
+			public const int Base_TextAppearance_AppCompat_Subhead = 2131230787;
 			
-			// aapt resource value: 0x7f0c00a5
-			public const int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131493029;
+			// aapt resource value: 0x7f0800a6
+			public const int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131230886;
 			
-			// aapt resource value: 0x7f0c0043
-			public const int Base_TextAppearance_AppCompat_Title = 2131492931;
+			// aapt resource value: 0x7f080044
+			public const int Base_TextAppearance_AppCompat_Title = 2131230788;
 			
-			// aapt resource value: 0x7f0c00a6
-			public const int Base_TextAppearance_AppCompat_Title_Inverse = 2131493030;
+			// aapt resource value: 0x7f0800a7
+			public const int Base_TextAppearance_AppCompat_Title_Inverse = 2131230887;
 			
-			// aapt resource value: 0x7f0c00a7
-			public const int Base_TextAppearance_AppCompat_Tooltip = 2131493031;
+			// aapt resource value: 0x7f0800a8
+			public const int Base_TextAppearance_AppCompat_Tooltip = 2131230888;
 			
-			// aapt resource value: 0x7f0c0087
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131492999;
+			// aapt resource value: 0x7f080088
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131230856;
 			
-			// aapt resource value: 0x7f0c0044
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131492932;
+			// aapt resource value: 0x7f080045
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131230789;
 			
-			// aapt resource value: 0x7f0c0045
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131492933;
+			// aapt resource value: 0x7f080046
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131230790;
 			
-			// aapt resource value: 0x7f0c0046
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131492934;
+			// aapt resource value: 0x7f080047
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131230791;
 			
-			// aapt resource value: 0x7f0c0047
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131492935;
+			// aapt resource value: 0x7f080048
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131230792;
 			
-			// aapt resource value: 0x7f0c0048
-			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131492936;
+			// aapt resource value: 0x7f080049
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131230793;
 			
-			// aapt resource value: 0x7f0c0049
-			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131492937;
+			// aapt resource value: 0x7f08004a
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131230794;
 			
-			// aapt resource value: 0x7f0c004a
-			public const int Base_TextAppearance_AppCompat_Widget_Button = 2131492938;
+			// aapt resource value: 0x7f08004b
+			public const int Base_TextAppearance_AppCompat_Widget_Button = 2131230795;
 			
-			// aapt resource value: 0x7f0c008e
-			public const int Base_TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131493006;
+			// aapt resource value: 0x7f08008f
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131230863;
 			
-			// aapt resource value: 0x7f0c008f
-			public const int Base_TextAppearance_AppCompat_Widget_Button_Colored = 2131493007;
+			// aapt resource value: 0x7f080090
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Colored = 2131230864;
 			
-			// aapt resource value: 0x7f0c0088
-			public const int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131493000;
+			// aapt resource value: 0x7f080089
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131230857;
 			
-			// aapt resource value: 0x7f0c00a8
-			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131493032;
+			// aapt resource value: 0x7f0800a9
+			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131230889;
 			
-			// aapt resource value: 0x7f0c004b
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131492939;
+			// aapt resource value: 0x7f08004c
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131230796;
 			
-			// aapt resource value: 0x7f0c004c
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131492940;
+			// aapt resource value: 0x7f08004d
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131230797;
 			
-			// aapt resource value: 0x7f0c004d
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131492941;
+			// aapt resource value: 0x7f08004e
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131230798;
 			
-			// aapt resource value: 0x7f0c004e
-			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131492942;
+			// aapt resource value: 0x7f08004f
+			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131230799;
 			
-			// aapt resource value: 0x7f0c004f
-			public const int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131492943;
+			// aapt resource value: 0x7f080050
+			public const int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131230800;
 			
-			// aapt resource value: 0x7f0c00a9
-			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131493033;
+			// aapt resource value: 0x7f0800aa
+			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131230890;
 			
-			// aapt resource value: 0x7f0c0050
-			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131492944;
+			// aapt resource value: 0x7f080051
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131230801;
 			
-			// aapt resource value: 0x7f0c0051
-			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131492945;
+			// aapt resource value: 0x7f080052
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131230802;
 			
-			// aapt resource value: 0x7f0c0052
-			public const int Base_Theme_AppCompat = 2131492946;
+			// aapt resource value: 0x7f080053
+			public const int Base_Theme_AppCompat = 2131230803;
 			
-			// aapt resource value: 0x7f0c00aa
-			public const int Base_Theme_AppCompat_CompactMenu = 2131493034;
+			// aapt resource value: 0x7f0800ab
+			public const int Base_Theme_AppCompat_CompactMenu = 2131230891;
 			
-			// aapt resource value: 0x7f0c0053
-			public const int Base_Theme_AppCompat_Dialog = 2131492947;
+			// aapt resource value: 0x7f080054
+			public const int Base_Theme_AppCompat_Dialog = 2131230804;
 			
-			// aapt resource value: 0x7f0c00ab
-			public const int Base_Theme_AppCompat_Dialog_Alert = 2131493035;
+			// aapt resource value: 0x7f0800ac
+			public const int Base_Theme_AppCompat_Dialog_Alert = 2131230892;
 			
-			// aapt resource value: 0x7f0c00ac
-			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131493036;
+			// aapt resource value: 0x7f0800ad
+			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131230893;
 			
-			// aapt resource value: 0x7f0c00ad
-			public const int Base_Theme_AppCompat_Dialog_MinWidth = 2131493037;
+			// aapt resource value: 0x7f0800ae
+			public const int Base_Theme_AppCompat_Dialog_MinWidth = 2131230894;
 			
-			// aapt resource value: 0x7f0c0010
-			public const int Base_Theme_AppCompat_DialogWhenLarge = 2131492880;
+			// aapt resource value: 0x7f080011
+			public const int Base_Theme_AppCompat_DialogWhenLarge = 2131230737;
 			
-			// aapt resource value: 0x7f0c0054
-			public const int Base_Theme_AppCompat_Light = 2131492948;
+			// aapt resource value: 0x7f080055
+			public const int Base_Theme_AppCompat_Light = 2131230805;
 			
-			// aapt resource value: 0x7f0c00ae
-			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131493038;
+			// aapt resource value: 0x7f0800af
+			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131230895;
 			
-			// aapt resource value: 0x7f0c0055
-			public const int Base_Theme_AppCompat_Light_Dialog = 2131492949;
+			// aapt resource value: 0x7f080056
+			public const int Base_Theme_AppCompat_Light_Dialog = 2131230806;
 			
-			// aapt resource value: 0x7f0c00af
-			public const int Base_Theme_AppCompat_Light_Dialog_Alert = 2131493039;
+			// aapt resource value: 0x7f0800b0
+			public const int Base_Theme_AppCompat_Light_Dialog_Alert = 2131230896;
 			
-			// aapt resource value: 0x7f0c00b0
-			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131493040;
+			// aapt resource value: 0x7f0800b1
+			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131230897;
 			
-			// aapt resource value: 0x7f0c00b1
-			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131493041;
+			// aapt resource value: 0x7f0800b2
+			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131230898;
 			
-			// aapt resource value: 0x7f0c0011
-			public const int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131492881;
+			// aapt resource value: 0x7f080012
+			public const int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131230738;
 			
-			// aapt resource value: 0x7f0c016e
-			public const int Base_Theme_MaterialComponents = 2131493230;
+			// aapt resource value: 0x7f08016f
+			public const int Base_Theme_MaterialComponents = 2131231087;
 			
-			// aapt resource value: 0x7f0c016f
-			public const int Base_Theme_MaterialComponents_Bridge = 2131493231;
+			// aapt resource value: 0x7f080170
+			public const int Base_Theme_MaterialComponents_Bridge = 2131231088;
 			
-			// aapt resource value: 0x7f0c0170
-			public const int Base_Theme_MaterialComponents_CompactMenu = 2131493232;
+			// aapt resource value: 0x7f080171
+			public const int Base_Theme_MaterialComponents_CompactMenu = 2131231089;
 			
-			// aapt resource value: 0x7f0c0171
-			public const int Base_Theme_MaterialComponents_Dialog = 2131493233;
+			// aapt resource value: 0x7f080172
+			public const int Base_Theme_MaterialComponents_Dialog = 2131231090;
 			
-			// aapt resource value: 0x7f0c0172
-			public const int Base_Theme_MaterialComponents_Dialog_Alert = 2131493234;
+			// aapt resource value: 0x7f080173
+			public const int Base_Theme_MaterialComponents_Dialog_Alert = 2131231091;
 			
-			// aapt resource value: 0x7f0c0173
-			public const int Base_Theme_MaterialComponents_Dialog_FixedSize = 2131493235;
+			// aapt resource value: 0x7f080174
+			public const int Base_Theme_MaterialComponents_Dialog_FixedSize = 2131231092;
 			
-			// aapt resource value: 0x7f0c0174
-			public const int Base_Theme_MaterialComponents_Dialog_MinWidth = 2131493236;
+			// aapt resource value: 0x7f080175
+			public const int Base_Theme_MaterialComponents_Dialog_MinWidth = 2131231093;
 			
-			// aapt resource value: 0x7f0c0167
-			public const int Base_Theme_MaterialComponents_DialogWhenLarge = 2131493223;
+			// aapt resource value: 0x7f080168
+			public const int Base_Theme_MaterialComponents_DialogWhenLarge = 2131231080;
 			
-			// aapt resource value: 0x7f0c0175
-			public const int Base_Theme_MaterialComponents_Light = 2131493237;
+			// aapt resource value: 0x7f080176
+			public const int Base_Theme_MaterialComponents_Light = 2131231094;
 			
-			// aapt resource value: 0x7f0c0176
-			public const int Base_Theme_MaterialComponents_Light_Bridge = 2131493238;
+			// aapt resource value: 0x7f080177
+			public const int Base_Theme_MaterialComponents_Light_Bridge = 2131231095;
 			
-			// aapt resource value: 0x7f0c0177
-			public const int Base_Theme_MaterialComponents_Light_DarkActionBar = 2131493239;
+			// aapt resource value: 0x7f080178
+			public const int Base_Theme_MaterialComponents_Light_DarkActionBar = 2131231096;
 			
-			// aapt resource value: 0x7f0c0178
-			public const int Base_Theme_MaterialComponents_Light_DarkActionBar_Bridge = 2131493240;
+			// aapt resource value: 0x7f080179
+			public const int Base_Theme_MaterialComponents_Light_DarkActionBar_Bridge = 2131231097;
 			
-			// aapt resource value: 0x7f0c0179
-			public const int Base_Theme_MaterialComponents_Light_Dialog = 2131493241;
+			// aapt resource value: 0x7f08017a
+			public const int Base_Theme_MaterialComponents_Light_Dialog = 2131231098;
 			
-			// aapt resource value: 0x7f0c017a
-			public const int Base_Theme_MaterialComponents_Light_Dialog_Alert = 2131493242;
+			// aapt resource value: 0x7f08017b
+			public const int Base_Theme_MaterialComponents_Light_Dialog_Alert = 2131231099;
 			
-			// aapt resource value: 0x7f0c017b
-			public const int Base_Theme_MaterialComponents_Light_Dialog_FixedSize = 2131493243;
+			// aapt resource value: 0x7f08017c
+			public const int Base_Theme_MaterialComponents_Light_Dialog_FixedSize = 2131231100;
 			
-			// aapt resource value: 0x7f0c017c
-			public const int Base_Theme_MaterialComponents_Light_Dialog_MinWidth = 2131493244;
+			// aapt resource value: 0x7f08017d
+			public const int Base_Theme_MaterialComponents_Light_Dialog_MinWidth = 2131231101;
 			
-			// aapt resource value: 0x7f0c0168
-			public const int Base_Theme_MaterialComponents_Light_DialogWhenLarge = 2131493224;
+			// aapt resource value: 0x7f080169
+			public const int Base_Theme_MaterialComponents_Light_DialogWhenLarge = 2131231081;
 			
-			// aapt resource value: 0x7f0c00b2
-			public const int Base_ThemeOverlay_AppCompat = 2131493042;
+			// aapt resource value: 0x7f0800b3
+			public const int Base_ThemeOverlay_AppCompat = 2131230899;
 			
-			// aapt resource value: 0x7f0c00b3
-			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131493043;
+			// aapt resource value: 0x7f0800b4
+			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131230900;
 			
-			// aapt resource value: 0x7f0c00b4
-			public const int Base_ThemeOverlay_AppCompat_Dark = 2131493044;
+			// aapt resource value: 0x7f0800b5
+			public const int Base_ThemeOverlay_AppCompat_Dark = 2131230901;
 			
-			// aapt resource value: 0x7f0c00b5
-			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131493045;
+			// aapt resource value: 0x7f0800b6
+			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131230902;
 			
-			// aapt resource value: 0x7f0c0056
-			public const int Base_ThemeOverlay_AppCompat_Dialog = 2131492950;
+			// aapt resource value: 0x7f080057
+			public const int Base_ThemeOverlay_AppCompat_Dialog = 2131230807;
 			
-			// aapt resource value: 0x7f0c00b6
-			public const int Base_ThemeOverlay_AppCompat_Dialog_Alert = 2131493046;
+			// aapt resource value: 0x7f0800b7
+			public const int Base_ThemeOverlay_AppCompat_Dialog_Alert = 2131230903;
 			
-			// aapt resource value: 0x7f0c00b7
-			public const int Base_ThemeOverlay_AppCompat_Light = 2131493047;
+			// aapt resource value: 0x7f0800b8
+			public const int Base_ThemeOverlay_AppCompat_Light = 2131230904;
 			
-			// aapt resource value: 0x7f0c017d
-			public const int Base_ThemeOverlay_MaterialComponents_Dialog = 2131493245;
+			// aapt resource value: 0x7f08017e
+			public const int Base_ThemeOverlay_MaterialComponents_Dialog = 2131231102;
 			
-			// aapt resource value: 0x7f0c017e
-			public const int Base_ThemeOverlay_MaterialComponents_Dialog_Alert = 2131493246;
+			// aapt resource value: 0x7f08017f
+			public const int Base_ThemeOverlay_MaterialComponents_Dialog_Alert = 2131231103;
 			
-			// aapt resource value: 0x7f0c017f
-			public const int Base_V14_Theme_MaterialComponents = 2131493247;
+			// aapt resource value: 0x7f080180
+			public const int Base_V14_Theme_MaterialComponents = 2131231104;
 			
-			// aapt resource value: 0x7f0c0180
-			public const int Base_V14_Theme_MaterialComponents_Bridge = 2131493248;
+			// aapt resource value: 0x7f080181
+			public const int Base_V14_Theme_MaterialComponents_Bridge = 2131231105;
 			
-			// aapt resource value: 0x7f0c0181
-			public const int Base_V14_Theme_MaterialComponents_Dialog = 2131493249;
+			// aapt resource value: 0x7f080182
+			public const int Base_V14_Theme_MaterialComponents_Dialog = 2131231106;
 			
-			// aapt resource value: 0x7f0c0182
-			public const int Base_V14_Theme_MaterialComponents_Light = 2131493250;
+			// aapt resource value: 0x7f080183
+			public const int Base_V14_Theme_MaterialComponents_Light = 2131231107;
 			
-			// aapt resource value: 0x7f0c0183
-			public const int Base_V14_Theme_MaterialComponents_Light_Bridge = 2131493251;
+			// aapt resource value: 0x7f080184
+			public const int Base_V14_Theme_MaterialComponents_Light_Bridge = 2131231108;
 			
-			// aapt resource value: 0x7f0c0184
-			public const int Base_V14_Theme_MaterialComponents_Light_DarkActionBar_Bridge = 2131493252;
+			// aapt resource value: 0x7f080185
+			public const int Base_V14_Theme_MaterialComponents_Light_DarkActionBar_Bridge = 2131231109;
 			
-			// aapt resource value: 0x7f0c0185
-			public const int Base_V14_Theme_MaterialComponents_Light_Dialog = 2131493253;
+			// aapt resource value: 0x7f080186
+			public const int Base_V14_Theme_MaterialComponents_Light_Dialog = 2131231110;
 			
-			// aapt resource value: 0x7f0c0186
-			public const int Base_V14_ThemeOverlay_MaterialComponents_Dialog = 2131493254;
+			// aapt resource value: 0x7f080187
+			public const int Base_V14_ThemeOverlay_MaterialComponents_Dialog = 2131231111;
 			
-			// aapt resource value: 0x7f0c0187
-			public const int Base_V14_ThemeOverlay_MaterialComponents_Dialog_Alert = 2131493255;
+			// aapt resource value: 0x7f080188
+			public const int Base_V14_ThemeOverlay_MaterialComponents_Dialog_Alert = 2131231112;
 			
-			// aapt resource value: 0x7f0c0057
-			public const int Base_V21_Theme_AppCompat = 2131492951;
+			// aapt resource value: 0x7f080058
+			public const int Base_V21_Theme_AppCompat = 2131230808;
 			
-			// aapt resource value: 0x7f0c0058
-			public const int Base_V21_Theme_AppCompat_Dialog = 2131492952;
+			// aapt resource value: 0x7f080059
+			public const int Base_V21_Theme_AppCompat_Dialog = 2131230809;
 			
-			// aapt resource value: 0x7f0c0059
-			public const int Base_V21_Theme_AppCompat_Light = 2131492953;
+			// aapt resource value: 0x7f08005a
+			public const int Base_V21_Theme_AppCompat_Light = 2131230810;
 			
-			// aapt resource value: 0x7f0c005a
-			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131492954;
+			// aapt resource value: 0x7f08005b
+			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131230811;
 			
-			// aapt resource value: 0x7f0c005b
-			public const int Base_V21_ThemeOverlay_AppCompat_Dialog = 2131492955;
+			// aapt resource value: 0x7f08005c
+			public const int Base_V21_ThemeOverlay_AppCompat_Dialog = 2131230812;
 			
-			// aapt resource value: 0x7f0c0085
-			public const int Base_V22_Theme_AppCompat = 2131492997;
+			// aapt resource value: 0x7f080086
+			public const int Base_V22_Theme_AppCompat = 2131230854;
 			
-			// aapt resource value: 0x7f0c0086
-			public const int Base_V22_Theme_AppCompat_Light = 2131492998;
+			// aapt resource value: 0x7f080087
+			public const int Base_V22_Theme_AppCompat_Light = 2131230855;
 			
-			// aapt resource value: 0x7f0c0089
-			public const int Base_V23_Theme_AppCompat = 2131493001;
+			// aapt resource value: 0x7f08008a
+			public const int Base_V23_Theme_AppCompat = 2131230858;
 			
-			// aapt resource value: 0x7f0c008a
-			public const int Base_V23_Theme_AppCompat_Light = 2131493002;
+			// aapt resource value: 0x7f08008b
+			public const int Base_V23_Theme_AppCompat_Light = 2131230859;
 			
-			// aapt resource value: 0x7f0c0092
-			public const int Base_V26_Theme_AppCompat = 2131493010;
+			// aapt resource value: 0x7f080093
+			public const int Base_V26_Theme_AppCompat = 2131230867;
 			
-			// aapt resource value: 0x7f0c0093
-			public const int Base_V26_Theme_AppCompat_Light = 2131493011;
+			// aapt resource value: 0x7f080094
+			public const int Base_V26_Theme_AppCompat_Light = 2131230868;
 			
-			// aapt resource value: 0x7f0c0094
-			public const int Base_V26_Widget_AppCompat_Toolbar = 2131493012;
+			// aapt resource value: 0x7f080095
+			public const int Base_V26_Widget_AppCompat_Toolbar = 2131230869;
 			
-			// aapt resource value: 0x7f0c0096
-			public const int Base_V28_Theme_AppCompat = 2131493014;
+			// aapt resource value: 0x7f080097
+			public const int Base_V28_Theme_AppCompat = 2131230871;
 			
-			// aapt resource value: 0x7f0c0097
-			public const int Base_V28_Theme_AppCompat_Light = 2131493015;
+			// aapt resource value: 0x7f080098
+			public const int Base_V28_Theme_AppCompat_Light = 2131230872;
 			
-			// aapt resource value: 0x7f0c00b8
-			public const int Base_V7_Theme_AppCompat = 2131493048;
+			// aapt resource value: 0x7f0800b9
+			public const int Base_V7_Theme_AppCompat = 2131230905;
 			
-			// aapt resource value: 0x7f0c00b9
-			public const int Base_V7_Theme_AppCompat_Dialog = 2131493049;
+			// aapt resource value: 0x7f0800ba
+			public const int Base_V7_Theme_AppCompat_Dialog = 2131230906;
 			
-			// aapt resource value: 0x7f0c00ba
-			public const int Base_V7_Theme_AppCompat_Light = 2131493050;
+			// aapt resource value: 0x7f0800bb
+			public const int Base_V7_Theme_AppCompat_Light = 2131230907;
 			
-			// aapt resource value: 0x7f0c00bb
-			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131493051;
+			// aapt resource value: 0x7f0800bc
+			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131230908;
 			
-			// aapt resource value: 0x7f0c00bc
-			public const int Base_V7_ThemeOverlay_AppCompat_Dialog = 2131493052;
+			// aapt resource value: 0x7f0800bd
+			public const int Base_V7_ThemeOverlay_AppCompat_Dialog = 2131230909;
 			
-			// aapt resource value: 0x7f0c00bd
-			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131493053;
+			// aapt resource value: 0x7f0800be
+			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131230910;
 			
-			// aapt resource value: 0x7f0c00be
-			public const int Base_V7_Widget_AppCompat_EditText = 2131493054;
+			// aapt resource value: 0x7f0800bf
+			public const int Base_V7_Widget_AppCompat_EditText = 2131230911;
 			
-			// aapt resource value: 0x7f0c00bf
-			public const int Base_V7_Widget_AppCompat_Toolbar = 2131493055;
+			// aapt resource value: 0x7f0800c0
+			public const int Base_V7_Widget_AppCompat_Toolbar = 2131230912;
 			
-			// aapt resource value: 0x7f0c00c0
-			public const int Base_Widget_AppCompat_ActionBar = 2131493056;
+			// aapt resource value: 0x7f0800c1
+			public const int Base_Widget_AppCompat_ActionBar = 2131230913;
 			
-			// aapt resource value: 0x7f0c00c1
-			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131493057;
+			// aapt resource value: 0x7f0800c2
+			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131230914;
 			
-			// aapt resource value: 0x7f0c00c2
-			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131493058;
+			// aapt resource value: 0x7f0800c3
+			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131230915;
 			
-			// aapt resource value: 0x7f0c005c
-			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131492956;
+			// aapt resource value: 0x7f08005d
+			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131230813;
 			
-			// aapt resource value: 0x7f0c005d
-			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131492957;
+			// aapt resource value: 0x7f08005e
+			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131230814;
 			
-			// aapt resource value: 0x7f0c005e
-			public const int Base_Widget_AppCompat_ActionButton = 2131492958;
+			// aapt resource value: 0x7f08005f
+			public const int Base_Widget_AppCompat_ActionButton = 2131230815;
 			
-			// aapt resource value: 0x7f0c005f
-			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131492959;
+			// aapt resource value: 0x7f080060
+			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131230816;
 			
-			// aapt resource value: 0x7f0c0060
-			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131492960;
+			// aapt resource value: 0x7f080061
+			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131230817;
 			
-			// aapt resource value: 0x7f0c00c3
-			public const int Base_Widget_AppCompat_ActionMode = 2131493059;
+			// aapt resource value: 0x7f0800c4
+			public const int Base_Widget_AppCompat_ActionMode = 2131230916;
 			
-			// aapt resource value: 0x7f0c00c4
-			public const int Base_Widget_AppCompat_ActivityChooserView = 2131493060;
+			// aapt resource value: 0x7f0800c5
+			public const int Base_Widget_AppCompat_ActivityChooserView = 2131230917;
 			
-			// aapt resource value: 0x7f0c0061
-			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131492961;
+			// aapt resource value: 0x7f080062
+			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131230818;
 			
-			// aapt resource value: 0x7f0c0062
-			public const int Base_Widget_AppCompat_Button = 2131492962;
+			// aapt resource value: 0x7f080063
+			public const int Base_Widget_AppCompat_Button = 2131230819;
 			
-			// aapt resource value: 0x7f0c0063
-			public const int Base_Widget_AppCompat_Button_Borderless = 2131492963;
+			// aapt resource value: 0x7f080064
+			public const int Base_Widget_AppCompat_Button_Borderless = 2131230820;
 			
-			// aapt resource value: 0x7f0c0064
-			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131492964;
+			// aapt resource value: 0x7f080065
+			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131230821;
 			
-			// aapt resource value: 0x7f0c00c5
-			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131493061;
+			// aapt resource value: 0x7f0800c6
+			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131230918;
 			
-			// aapt resource value: 0x7f0c008b
-			public const int Base_Widget_AppCompat_Button_Colored = 2131493003;
+			// aapt resource value: 0x7f08008c
+			public const int Base_Widget_AppCompat_Button_Colored = 2131230860;
 			
-			// aapt resource value: 0x7f0c0065
-			public const int Base_Widget_AppCompat_Button_Small = 2131492965;
+			// aapt resource value: 0x7f080066
+			public const int Base_Widget_AppCompat_Button_Small = 2131230822;
 			
-			// aapt resource value: 0x7f0c0066
-			public const int Base_Widget_AppCompat_ButtonBar = 2131492966;
+			// aapt resource value: 0x7f080067
+			public const int Base_Widget_AppCompat_ButtonBar = 2131230823;
 			
-			// aapt resource value: 0x7f0c00c6
-			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131493062;
+			// aapt resource value: 0x7f0800c7
+			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131230919;
 			
-			// aapt resource value: 0x7f0c0067
-			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131492967;
+			// aapt resource value: 0x7f080068
+			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131230824;
 			
-			// aapt resource value: 0x7f0c0068
-			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131492968;
+			// aapt resource value: 0x7f080069
+			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131230825;
 			
-			// aapt resource value: 0x7f0c00c7
-			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131493063;
+			// aapt resource value: 0x7f0800c8
+			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131230920;
 			
-			// aapt resource value: 0x7f0c000f
-			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131492879;
+			// aapt resource value: 0x7f080010
+			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131230736;
 			
-			// aapt resource value: 0x7f0c00c8
-			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131493064;
+			// aapt resource value: 0x7f0800c9
+			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131230921;
 			
-			// aapt resource value: 0x7f0c0069
-			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131492969;
+			// aapt resource value: 0x7f08006a
+			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131230826;
 			
-			// aapt resource value: 0x7f0c006a
-			public const int Base_Widget_AppCompat_EditText = 2131492970;
+			// aapt resource value: 0x7f08006b
+			public const int Base_Widget_AppCompat_EditText = 2131230827;
 			
-			// aapt resource value: 0x7f0c006b
-			public const int Base_Widget_AppCompat_ImageButton = 2131492971;
+			// aapt resource value: 0x7f08006c
+			public const int Base_Widget_AppCompat_ImageButton = 2131230828;
 			
-			// aapt resource value: 0x7f0c00c9
-			public const int Base_Widget_AppCompat_Light_ActionBar = 2131493065;
+			// aapt resource value: 0x7f0800ca
+			public const int Base_Widget_AppCompat_Light_ActionBar = 2131230922;
 			
-			// aapt resource value: 0x7f0c00ca
-			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131493066;
+			// aapt resource value: 0x7f0800cb
+			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131230923;
 			
-			// aapt resource value: 0x7f0c00cb
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131493067;
+			// aapt resource value: 0x7f0800cc
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131230924;
 			
-			// aapt resource value: 0x7f0c006c
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131492972;
+			// aapt resource value: 0x7f08006d
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131230829;
 			
-			// aapt resource value: 0x7f0c006d
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131492973;
+			// aapt resource value: 0x7f08006e
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131230830;
 			
-			// aapt resource value: 0x7f0c006e
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131492974;
+			// aapt resource value: 0x7f08006f
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131230831;
 			
-			// aapt resource value: 0x7f0c006f
-			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131492975;
+			// aapt resource value: 0x7f080070
+			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131230832;
 			
-			// aapt resource value: 0x7f0c0070
-			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131492976;
+			// aapt resource value: 0x7f080071
+			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131230833;
 			
-			// aapt resource value: 0x7f0c00cc
-			public const int Base_Widget_AppCompat_ListMenuView = 2131493068;
+			// aapt resource value: 0x7f0800cd
+			public const int Base_Widget_AppCompat_ListMenuView = 2131230925;
 			
-			// aapt resource value: 0x7f0c0071
-			public const int Base_Widget_AppCompat_ListPopupWindow = 2131492977;
+			// aapt resource value: 0x7f080072
+			public const int Base_Widget_AppCompat_ListPopupWindow = 2131230834;
 			
-			// aapt resource value: 0x7f0c0072
-			public const int Base_Widget_AppCompat_ListView = 2131492978;
+			// aapt resource value: 0x7f080073
+			public const int Base_Widget_AppCompat_ListView = 2131230835;
 			
-			// aapt resource value: 0x7f0c0073
-			public const int Base_Widget_AppCompat_ListView_DropDown = 2131492979;
+			// aapt resource value: 0x7f080074
+			public const int Base_Widget_AppCompat_ListView_DropDown = 2131230836;
 			
-			// aapt resource value: 0x7f0c0074
-			public const int Base_Widget_AppCompat_ListView_Menu = 2131492980;
+			// aapt resource value: 0x7f080075
+			public const int Base_Widget_AppCompat_ListView_Menu = 2131230837;
 			
-			// aapt resource value: 0x7f0c0075
-			public const int Base_Widget_AppCompat_PopupMenu = 2131492981;
+			// aapt resource value: 0x7f080076
+			public const int Base_Widget_AppCompat_PopupMenu = 2131230838;
 			
-			// aapt resource value: 0x7f0c0076
-			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131492982;
+			// aapt resource value: 0x7f080077
+			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131230839;
 			
-			// aapt resource value: 0x7f0c00cd
-			public const int Base_Widget_AppCompat_PopupWindow = 2131493069;
+			// aapt resource value: 0x7f0800ce
+			public const int Base_Widget_AppCompat_PopupWindow = 2131230926;
 			
-			// aapt resource value: 0x7f0c0077
-			public const int Base_Widget_AppCompat_ProgressBar = 2131492983;
+			// aapt resource value: 0x7f080078
+			public const int Base_Widget_AppCompat_ProgressBar = 2131230840;
 			
-			// aapt resource value: 0x7f0c0078
-			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131492984;
+			// aapt resource value: 0x7f080079
+			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131230841;
 			
-			// aapt resource value: 0x7f0c0079
-			public const int Base_Widget_AppCompat_RatingBar = 2131492985;
+			// aapt resource value: 0x7f08007a
+			public const int Base_Widget_AppCompat_RatingBar = 2131230842;
 			
-			// aapt resource value: 0x7f0c008c
-			public const int Base_Widget_AppCompat_RatingBar_Indicator = 2131493004;
+			// aapt resource value: 0x7f08008d
+			public const int Base_Widget_AppCompat_RatingBar_Indicator = 2131230861;
 			
-			// aapt resource value: 0x7f0c008d
-			public const int Base_Widget_AppCompat_RatingBar_Small = 2131493005;
+			// aapt resource value: 0x7f08008e
+			public const int Base_Widget_AppCompat_RatingBar_Small = 2131230862;
 			
-			// aapt resource value: 0x7f0c00ce
-			public const int Base_Widget_AppCompat_SearchView = 2131493070;
+			// aapt resource value: 0x7f0800cf
+			public const int Base_Widget_AppCompat_SearchView = 2131230927;
 			
-			// aapt resource value: 0x7f0c00cf
-			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131493071;
+			// aapt resource value: 0x7f0800d0
+			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131230928;
 			
-			// aapt resource value: 0x7f0c007a
-			public const int Base_Widget_AppCompat_SeekBar = 2131492986;
+			// aapt resource value: 0x7f08007b
+			public const int Base_Widget_AppCompat_SeekBar = 2131230843;
 			
-			// aapt resource value: 0x7f0c00d0
-			public const int Base_Widget_AppCompat_SeekBar_Discrete = 2131493072;
+			// aapt resource value: 0x7f0800d1
+			public const int Base_Widget_AppCompat_SeekBar_Discrete = 2131230929;
 			
-			// aapt resource value: 0x7f0c007b
-			public const int Base_Widget_AppCompat_Spinner = 2131492987;
+			// aapt resource value: 0x7f08007c
+			public const int Base_Widget_AppCompat_Spinner = 2131230844;
 			
-			// aapt resource value: 0x7f0c0012
-			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131492882;
+			// aapt resource value: 0x7f080013
+			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131230739;
 			
-			// aapt resource value: 0x7f0c007c
-			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131492988;
+			// aapt resource value: 0x7f08007d
+			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131230845;
 			
-			// aapt resource value: 0x7f0c0095
-			public const int Base_Widget_AppCompat_Toolbar = 2131493013;
+			// aapt resource value: 0x7f080096
+			public const int Base_Widget_AppCompat_Toolbar = 2131230870;
 			
-			// aapt resource value: 0x7f0c007d
-			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131492989;
+			// aapt resource value: 0x7f08007e
+			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131230846;
 			
-			// aapt resource value: 0x7f0c0188
-			public const int Base_Widget_Design_TabLayout = 2131493256;
+			// aapt resource value: 0x7f080189
+			public const int Base_Widget_Design_TabLayout = 2131231113;
 			
-			// aapt resource value: 0x7f0c0189
-			public const int Base_Widget_MaterialComponents_Chip = 2131493257;
+			// aapt resource value: 0x7f08018a
+			public const int Base_Widget_MaterialComponents_Chip = 2131231114;
 			
-			// aapt resource value: 0x7f0c018a
-			public const int Base_Widget_MaterialComponents_TextInputEditText = 2131493258;
+			// aapt resource value: 0x7f08018b
+			public const int Base_Widget_MaterialComponents_TextInputEditText = 2131231115;
 			
-			// aapt resource value: 0x7f0c018b
-			public const int Base_Widget_MaterialComponents_TextInputLayout = 2131493259;
+			// aapt resource value: 0x7f08018c
+			public const int Base_Widget_MaterialComponents_TextInputLayout = 2131231116;
 			
-			// aapt resource value: 0x7f0c000b
-			public const int CardView = 2131492875;
+			// aapt resource value: 0x7f08000c
+			public const int CardView = 2131230732;
 			
-			// aapt resource value: 0x7f0c000d
-			public const int CardView_Dark = 2131492877;
+			// aapt resource value: 0x7f08000e
+			public const int CardView_Dark = 2131230734;
 			
-			// aapt resource value: 0x7f0c000e
-			public const int CardView_Light = 2131492878;
+			// aapt resource value: 0x7f08000f
+			public const int CardView_Light = 2131230735;
 			
-			// aapt resource value: 0x7f0c0200
-			public const int MyTheme = 2131493376;
+			// aapt resource value: 0x7f080201
+			public const int MyTheme = 2131231233;
 			
-			// aapt resource value: 0x7f0c0201
-			public const int MyTheme_Base = 2131493377;
+			// aapt resource value: 0x7f080202
+			public const int MyTheme_Base = 2131231234;
 			
-			// aapt resource value: 0x7f0c007e
-			public const int Platform_AppCompat = 2131492990;
+			// aapt resource value: 0x7f08007f
+			public const int Platform_AppCompat = 2131230847;
 			
-			// aapt resource value: 0x7f0c007f
-			public const int Platform_AppCompat_Light = 2131492991;
+			// aapt resource value: 0x7f080080
+			public const int Platform_AppCompat_Light = 2131230848;
 			
-			// aapt resource value: 0x7f0c018c
-			public const int Platform_MaterialComponents = 2131493260;
+			// aapt resource value: 0x7f08018d
+			public const int Platform_MaterialComponents = 2131231117;
 			
-			// aapt resource value: 0x7f0c018d
-			public const int Platform_MaterialComponents_Dialog = 2131493261;
+			// aapt resource value: 0x7f08018e
+			public const int Platform_MaterialComponents_Dialog = 2131231118;
 			
-			// aapt resource value: 0x7f0c018e
-			public const int Platform_MaterialComponents_Light = 2131493262;
+			// aapt resource value: 0x7f08018f
+			public const int Platform_MaterialComponents_Light = 2131231119;
 			
-			// aapt resource value: 0x7f0c018f
-			public const int Platform_MaterialComponents_Light_Dialog = 2131493263;
+			// aapt resource value: 0x7f080190
+			public const int Platform_MaterialComponents_Light_Dialog = 2131231120;
 			
-			// aapt resource value: 0x7f0c0080
-			public const int Platform_ThemeOverlay_AppCompat = 2131492992;
+			// aapt resource value: 0x7f080081
+			public const int Platform_ThemeOverlay_AppCompat = 2131230849;
 			
-			// aapt resource value: 0x7f0c0081
-			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131492993;
+			// aapt resource value: 0x7f080082
+			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131230850;
 			
-			// aapt resource value: 0x7f0c0082
-			public const int Platform_ThemeOverlay_AppCompat_Light = 2131492994;
+			// aapt resource value: 0x7f080083
+			public const int Platform_ThemeOverlay_AppCompat_Light = 2131230851;
 			
-			// aapt resource value: 0x7f0c0083
-			public const int Platform_V21_AppCompat = 2131492995;
+			// aapt resource value: 0x7f080084
+			public const int Platform_V21_AppCompat = 2131230852;
 			
-			// aapt resource value: 0x7f0c0084
-			public const int Platform_V21_AppCompat_Light = 2131492996;
+			// aapt resource value: 0x7f080085
+			public const int Platform_V21_AppCompat_Light = 2131230853;
 			
-			// aapt resource value: 0x7f0c0090
-			public const int Platform_V25_AppCompat = 2131493008;
+			// aapt resource value: 0x7f080091
+			public const int Platform_V25_AppCompat = 2131230865;
 			
-			// aapt resource value: 0x7f0c0091
-			public const int Platform_V25_AppCompat_Light = 2131493009;
+			// aapt resource value: 0x7f080092
+			public const int Platform_V25_AppCompat_Light = 2131230866;
 			
-			// aapt resource value: 0x7f0c00d1
-			public const int Platform_Widget_AppCompat_Spinner = 2131493073;
+			// aapt resource value: 0x7f0800d2
+			public const int Platform_Widget_AppCompat_Spinner = 2131230930;
 			
-			// aapt resource value: 0x7f0c001b
-			public const int RtlOverlay_DialogWindowTitle_AppCompat = 2131492891;
+			// aapt resource value: 0x7f08001c
+			public const int RtlOverlay_DialogWindowTitle_AppCompat = 2131230748;
 			
-			// aapt resource value: 0x7f0c001c
-			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131492892;
+			// aapt resource value: 0x7f08001d
+			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131230749;
 			
-			// aapt resource value: 0x7f0c001d
-			public const int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131492893;
+			// aapt resource value: 0x7f08001e
+			public const int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131230750;
 			
-			// aapt resource value: 0x7f0c001e
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131492894;
+			// aapt resource value: 0x7f08001f
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131230751;
 			
-			// aapt resource value: 0x7f0c001f
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131492895;
+			// aapt resource value: 0x7f080020
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131230752;
 			
-			// aapt resource value: 0x7f0c0020
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Shortcut = 2131492896;
+			// aapt resource value: 0x7f080021
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Shortcut = 2131230753;
 			
-			// aapt resource value: 0x7f0c0021
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_SubmenuArrow = 2131492897;
+			// aapt resource value: 0x7f080022
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_SubmenuArrow = 2131230754;
 			
-			// aapt resource value: 0x7f0c0022
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131492898;
+			// aapt resource value: 0x7f080023
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131230755;
 			
-			// aapt resource value: 0x7f0c0023
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Title = 2131492899;
+			// aapt resource value: 0x7f080024
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Title = 2131230756;
 			
-			// aapt resource value: 0x7f0c0024
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131492900;
+			// aapt resource value: 0x7f080025
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131230757;
 			
-			// aapt resource value: 0x7f0c0025
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131492901;
+			// aapt resource value: 0x7f080026
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131230758;
 			
-			// aapt resource value: 0x7f0c0026
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131492902;
+			// aapt resource value: 0x7f080027
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131230759;
 			
-			// aapt resource value: 0x7f0c0027
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131492903;
+			// aapt resource value: 0x7f080028
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131230760;
 			
-			// aapt resource value: 0x7f0c0028
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131492904;
+			// aapt resource value: 0x7f080029
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131230761;
 			
-			// aapt resource value: 0x7f0c0029
-			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131492905;
+			// aapt resource value: 0x7f08002a
+			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131230762;
 			
-			// aapt resource value: 0x7f0c002a
-			public const int RtlUnderlay_Widget_AppCompat_ActionButton = 2131492906;
+			// aapt resource value: 0x7f08002b
+			public const int RtlUnderlay_Widget_AppCompat_ActionButton = 2131230763;
 			
-			// aapt resource value: 0x7f0c002b
-			public const int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131492907;
+			// aapt resource value: 0x7f08002c
+			public const int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131230764;
 			
-			// aapt resource value: 0x7f0c00d2
-			public const int TextAppearance_AppCompat = 2131493074;
+			// aapt resource value: 0x7f0800d3
+			public const int TextAppearance_AppCompat = 2131230931;
 			
-			// aapt resource value: 0x7f0c00d3
-			public const int TextAppearance_AppCompat_Body1 = 2131493075;
+			// aapt resource value: 0x7f0800d4
+			public const int TextAppearance_AppCompat_Body1 = 2131230932;
 			
-			// aapt resource value: 0x7f0c00d4
-			public const int TextAppearance_AppCompat_Body2 = 2131493076;
+			// aapt resource value: 0x7f0800d5
+			public const int TextAppearance_AppCompat_Body2 = 2131230933;
 			
-			// aapt resource value: 0x7f0c00d5
-			public const int TextAppearance_AppCompat_Button = 2131493077;
+			// aapt resource value: 0x7f0800d6
+			public const int TextAppearance_AppCompat_Button = 2131230934;
 			
-			// aapt resource value: 0x7f0c00d6
-			public const int TextAppearance_AppCompat_Caption = 2131493078;
+			// aapt resource value: 0x7f0800d7
+			public const int TextAppearance_AppCompat_Caption = 2131230935;
 			
-			// aapt resource value: 0x7f0c00d7
-			public const int TextAppearance_AppCompat_Display1 = 2131493079;
+			// aapt resource value: 0x7f0800d8
+			public const int TextAppearance_AppCompat_Display1 = 2131230936;
 			
-			// aapt resource value: 0x7f0c00d8
-			public const int TextAppearance_AppCompat_Display2 = 2131493080;
+			// aapt resource value: 0x7f0800d9
+			public const int TextAppearance_AppCompat_Display2 = 2131230937;
 			
-			// aapt resource value: 0x7f0c00d9
-			public const int TextAppearance_AppCompat_Display3 = 2131493081;
+			// aapt resource value: 0x7f0800da
+			public const int TextAppearance_AppCompat_Display3 = 2131230938;
 			
-			// aapt resource value: 0x7f0c00da
-			public const int TextAppearance_AppCompat_Display4 = 2131493082;
+			// aapt resource value: 0x7f0800db
+			public const int TextAppearance_AppCompat_Display4 = 2131230939;
 			
-			// aapt resource value: 0x7f0c00db
-			public const int TextAppearance_AppCompat_Headline = 2131493083;
+			// aapt resource value: 0x7f0800dc
+			public const int TextAppearance_AppCompat_Headline = 2131230940;
 			
-			// aapt resource value: 0x7f0c00dc
-			public const int TextAppearance_AppCompat_Inverse = 2131493084;
+			// aapt resource value: 0x7f0800dd
+			public const int TextAppearance_AppCompat_Inverse = 2131230941;
 			
-			// aapt resource value: 0x7f0c00dd
-			public const int TextAppearance_AppCompat_Large = 2131493085;
+			// aapt resource value: 0x7f0800de
+			public const int TextAppearance_AppCompat_Large = 2131230942;
 			
-			// aapt resource value: 0x7f0c00de
-			public const int TextAppearance_AppCompat_Large_Inverse = 2131493086;
+			// aapt resource value: 0x7f0800df
+			public const int TextAppearance_AppCompat_Large_Inverse = 2131230943;
 			
-			// aapt resource value: 0x7f0c00df
-			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131493087;
+			// aapt resource value: 0x7f0800e0
+			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131230944;
 			
-			// aapt resource value: 0x7f0c00e0
-			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131493088;
+			// aapt resource value: 0x7f0800e1
+			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131230945;
 			
-			// aapt resource value: 0x7f0c00e1
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131493089;
+			// aapt resource value: 0x7f0800e2
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131230946;
 			
-			// aapt resource value: 0x7f0c00e2
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131493090;
+			// aapt resource value: 0x7f0800e3
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131230947;
 			
-			// aapt resource value: 0x7f0c00e3
-			public const int TextAppearance_AppCompat_Medium = 2131493091;
+			// aapt resource value: 0x7f0800e4
+			public const int TextAppearance_AppCompat_Medium = 2131230948;
 			
-			// aapt resource value: 0x7f0c00e4
-			public const int TextAppearance_AppCompat_Medium_Inverse = 2131493092;
+			// aapt resource value: 0x7f0800e5
+			public const int TextAppearance_AppCompat_Medium_Inverse = 2131230949;
 			
-			// aapt resource value: 0x7f0c00e5
-			public const int TextAppearance_AppCompat_Menu = 2131493093;
+			// aapt resource value: 0x7f0800e6
+			public const int TextAppearance_AppCompat_Menu = 2131230950;
 			
-			// aapt resource value: 0x7f0c00e6
-			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131493094;
+			// aapt resource value: 0x7f0800e7
+			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131230951;
 			
-			// aapt resource value: 0x7f0c00e7
-			public const int TextAppearance_AppCompat_SearchResult_Title = 2131493095;
+			// aapt resource value: 0x7f0800e8
+			public const int TextAppearance_AppCompat_SearchResult_Title = 2131230952;
 			
-			// aapt resource value: 0x7f0c00e8
-			public const int TextAppearance_AppCompat_Small = 2131493096;
+			// aapt resource value: 0x7f0800e9
+			public const int TextAppearance_AppCompat_Small = 2131230953;
 			
-			// aapt resource value: 0x7f0c00e9
-			public const int TextAppearance_AppCompat_Small_Inverse = 2131493097;
+			// aapt resource value: 0x7f0800ea
+			public const int TextAppearance_AppCompat_Small_Inverse = 2131230954;
 			
-			// aapt resource value: 0x7f0c00ea
-			public const int TextAppearance_AppCompat_Subhead = 2131493098;
+			// aapt resource value: 0x7f0800eb
+			public const int TextAppearance_AppCompat_Subhead = 2131230955;
 			
-			// aapt resource value: 0x7f0c00eb
-			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131493099;
+			// aapt resource value: 0x7f0800ec
+			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131230956;
 			
-			// aapt resource value: 0x7f0c00ec
-			public const int TextAppearance_AppCompat_Title = 2131493100;
+			// aapt resource value: 0x7f0800ed
+			public const int TextAppearance_AppCompat_Title = 2131230957;
 			
-			// aapt resource value: 0x7f0c00ed
-			public const int TextAppearance_AppCompat_Title_Inverse = 2131493101;
+			// aapt resource value: 0x7f0800ee
+			public const int TextAppearance_AppCompat_Title_Inverse = 2131230958;
 			
-			// aapt resource value: 0x7f0c001a
-			public const int TextAppearance_AppCompat_Tooltip = 2131492890;
+			// aapt resource value: 0x7f08001b
+			public const int TextAppearance_AppCompat_Tooltip = 2131230747;
 			
-			// aapt resource value: 0x7f0c00ee
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131493102;
+			// aapt resource value: 0x7f0800ef
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131230959;
 			
-			// aapt resource value: 0x7f0c00ef
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131493103;
+			// aapt resource value: 0x7f0800f0
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131230960;
 			
-			// aapt resource value: 0x7f0c00f0
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131493104;
+			// aapt resource value: 0x7f0800f1
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131230961;
 			
-			// aapt resource value: 0x7f0c00f1
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131493105;
+			// aapt resource value: 0x7f0800f2
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131230962;
 			
-			// aapt resource value: 0x7f0c00f2
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131493106;
+			// aapt resource value: 0x7f0800f3
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131230963;
 			
-			// aapt resource value: 0x7f0c00f3
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131493107;
+			// aapt resource value: 0x7f0800f4
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131230964;
 			
-			// aapt resource value: 0x7f0c00f4
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131493108;
+			// aapt resource value: 0x7f0800f5
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131230965;
 			
-			// aapt resource value: 0x7f0c00f5
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131493109;
+			// aapt resource value: 0x7f0800f6
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131230966;
 			
-			// aapt resource value: 0x7f0c00f6
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131493110;
+			// aapt resource value: 0x7f0800f7
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131230967;
 			
-			// aapt resource value: 0x7f0c00f7
-			public const int TextAppearance_AppCompat_Widget_Button = 2131493111;
+			// aapt resource value: 0x7f0800f8
+			public const int TextAppearance_AppCompat_Widget_Button = 2131230968;
 			
-			// aapt resource value: 0x7f0c00f8
-			public const int TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131493112;
+			// aapt resource value: 0x7f0800f9
+			public const int TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131230969;
 			
-			// aapt resource value: 0x7f0c00f9
-			public const int TextAppearance_AppCompat_Widget_Button_Colored = 2131493113;
+			// aapt resource value: 0x7f0800fa
+			public const int TextAppearance_AppCompat_Widget_Button_Colored = 2131230970;
 			
-			// aapt resource value: 0x7f0c00fa
-			public const int TextAppearance_AppCompat_Widget_Button_Inverse = 2131493114;
+			// aapt resource value: 0x7f0800fb
+			public const int TextAppearance_AppCompat_Widget_Button_Inverse = 2131230971;
 			
-			// aapt resource value: 0x7f0c00fb
-			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131493115;
+			// aapt resource value: 0x7f0800fc
+			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131230972;
 			
-			// aapt resource value: 0x7f0c00fc
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131493116;
+			// aapt resource value: 0x7f0800fd
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131230973;
 			
-			// aapt resource value: 0x7f0c00fd
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131493117;
+			// aapt resource value: 0x7f0800fe
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131230974;
 			
-			// aapt resource value: 0x7f0c00fe
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131493118;
+			// aapt resource value: 0x7f0800ff
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131230975;
 			
-			// aapt resource value: 0x7f0c00ff
-			public const int TextAppearance_AppCompat_Widget_Switch = 2131493119;
+			// aapt resource value: 0x7f080100
+			public const int TextAppearance_AppCompat_Widget_Switch = 2131230976;
 			
-			// aapt resource value: 0x7f0c0100
-			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131493120;
+			// aapt resource value: 0x7f080101
+			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131230977;
 			
-			// aapt resource value: 0x7f0c01f8
-			public const int TextAppearance_Compat_Notification = 2131493368;
+			// aapt resource value: 0x7f0801f9
+			public const int TextAppearance_Compat_Notification = 2131231225;
 			
-			// aapt resource value: 0x7f0c01f9
-			public const int TextAppearance_Compat_Notification_Info = 2131493369;
+			// aapt resource value: 0x7f0801fa
+			public const int TextAppearance_Compat_Notification_Info = 2131231226;
 			
-			// aapt resource value: 0x7f0c0161
-			public const int TextAppearance_Compat_Notification_Info_Media = 2131493217;
+			// aapt resource value: 0x7f080162
+			public const int TextAppearance_Compat_Notification_Info_Media = 2131231074;
 			
-			// aapt resource value: 0x7f0c01fe
-			public const int TextAppearance_Compat_Notification_Line2 = 2131493374;
+			// aapt resource value: 0x7f0801ff
+			public const int TextAppearance_Compat_Notification_Line2 = 2131231231;
 			
-			// aapt resource value: 0x7f0c0165
-			public const int TextAppearance_Compat_Notification_Line2_Media = 2131493221;
+			// aapt resource value: 0x7f080166
+			public const int TextAppearance_Compat_Notification_Line2_Media = 2131231078;
 			
-			// aapt resource value: 0x7f0c0162
-			public const int TextAppearance_Compat_Notification_Media = 2131493218;
+			// aapt resource value: 0x7f080163
+			public const int TextAppearance_Compat_Notification_Media = 2131231075;
 			
-			// aapt resource value: 0x7f0c01fa
-			public const int TextAppearance_Compat_Notification_Time = 2131493370;
+			// aapt resource value: 0x7f0801fb
+			public const int TextAppearance_Compat_Notification_Time = 2131231227;
 			
-			// aapt resource value: 0x7f0c0163
-			public const int TextAppearance_Compat_Notification_Time_Media = 2131493219;
+			// aapt resource value: 0x7f080164
+			public const int TextAppearance_Compat_Notification_Time_Media = 2131231076;
 			
-			// aapt resource value: 0x7f0c01fb
-			public const int TextAppearance_Compat_Notification_Title = 2131493371;
+			// aapt resource value: 0x7f0801fc
+			public const int TextAppearance_Compat_Notification_Title = 2131231228;
 			
-			// aapt resource value: 0x7f0c0164
-			public const int TextAppearance_Compat_Notification_Title_Media = 2131493220;
+			// aapt resource value: 0x7f080165
+			public const int TextAppearance_Compat_Notification_Title_Media = 2131231077;
 			
-			// aapt resource value: 0x7f0c0190
-			public const int TextAppearance_Design_CollapsingToolbar_Expanded = 2131493264;
+			// aapt resource value: 0x7f080191
+			public const int TextAppearance_Design_CollapsingToolbar_Expanded = 2131231121;
 			
-			// aapt resource value: 0x7f0c0191
-			public const int TextAppearance_Design_Counter = 2131493265;
+			// aapt resource value: 0x7f080192
+			public const int TextAppearance_Design_Counter = 2131231122;
 			
-			// aapt resource value: 0x7f0c0192
-			public const int TextAppearance_Design_Counter_Overflow = 2131493266;
+			// aapt resource value: 0x7f080193
+			public const int TextAppearance_Design_Counter_Overflow = 2131231123;
 			
-			// aapt resource value: 0x7f0c0193
-			public const int TextAppearance_Design_Error = 2131493267;
+			// aapt resource value: 0x7f080194
+			public const int TextAppearance_Design_Error = 2131231124;
 			
-			// aapt resource value: 0x7f0c0194
-			public const int TextAppearance_Design_HelperText = 2131493268;
+			// aapt resource value: 0x7f080195
+			public const int TextAppearance_Design_HelperText = 2131231125;
 			
-			// aapt resource value: 0x7f0c0195
-			public const int TextAppearance_Design_Hint = 2131493269;
+			// aapt resource value: 0x7f080196
+			public const int TextAppearance_Design_Hint = 2131231126;
 			
-			// aapt resource value: 0x7f0c0196
-			public const int TextAppearance_Design_Snackbar_Message = 2131493270;
+			// aapt resource value: 0x7f080197
+			public const int TextAppearance_Design_Snackbar_Message = 2131231127;
 			
-			// aapt resource value: 0x7f0c0197
-			public const int TextAppearance_Design_Tab = 2131493271;
+			// aapt resource value: 0x7f080198
+			public const int TextAppearance_Design_Tab = 2131231128;
 			
-			// aapt resource value: 0x7f0c0198
-			public const int TextAppearance_MaterialComponents_Body1 = 2131493272;
+			// aapt resource value: 0x7f080199
+			public const int TextAppearance_MaterialComponents_Body1 = 2131231129;
 			
-			// aapt resource value: 0x7f0c0199
-			public const int TextAppearance_MaterialComponents_Body2 = 2131493273;
+			// aapt resource value: 0x7f08019a
+			public const int TextAppearance_MaterialComponents_Body2 = 2131231130;
 			
-			// aapt resource value: 0x7f0c0169
-			public const int TextAppearance_MaterialComponents_Button = 2131493225;
+			// aapt resource value: 0x7f08016a
+			public const int TextAppearance_MaterialComponents_Button = 2131231082;
 			
-			// aapt resource value: 0x7f0c019a
-			public const int TextAppearance_MaterialComponents_Caption = 2131493274;
+			// aapt resource value: 0x7f08019b
+			public const int TextAppearance_MaterialComponents_Caption = 2131231131;
 			
-			// aapt resource value: 0x7f0c019b
-			public const int TextAppearance_MaterialComponents_Chip = 2131493275;
+			// aapt resource value: 0x7f08019c
+			public const int TextAppearance_MaterialComponents_Chip = 2131231132;
 			
-			// aapt resource value: 0x7f0c019c
-			public const int TextAppearance_MaterialComponents_Headline1 = 2131493276;
+			// aapt resource value: 0x7f08019d
+			public const int TextAppearance_MaterialComponents_Headline1 = 2131231133;
 			
-			// aapt resource value: 0x7f0c019d
-			public const int TextAppearance_MaterialComponents_Headline2 = 2131493277;
+			// aapt resource value: 0x7f08019e
+			public const int TextAppearance_MaterialComponents_Headline2 = 2131231134;
 			
-			// aapt resource value: 0x7f0c019e
-			public const int TextAppearance_MaterialComponents_Headline3 = 2131493278;
+			// aapt resource value: 0x7f08019f
+			public const int TextAppearance_MaterialComponents_Headline3 = 2131231135;
 			
-			// aapt resource value: 0x7f0c019f
-			public const int TextAppearance_MaterialComponents_Headline4 = 2131493279;
+			// aapt resource value: 0x7f0801a0
+			public const int TextAppearance_MaterialComponents_Headline4 = 2131231136;
 			
-			// aapt resource value: 0x7f0c01a0
-			public const int TextAppearance_MaterialComponents_Headline5 = 2131493280;
+			// aapt resource value: 0x7f0801a1
+			public const int TextAppearance_MaterialComponents_Headline5 = 2131231137;
 			
-			// aapt resource value: 0x7f0c016a
-			public const int TextAppearance_MaterialComponents_Headline6 = 2131493226;
+			// aapt resource value: 0x7f08016b
+			public const int TextAppearance_MaterialComponents_Headline6 = 2131231083;
 			
-			// aapt resource value: 0x7f0c016b
-			public const int TextAppearance_MaterialComponents_Overline = 2131493227;
+			// aapt resource value: 0x7f08016c
+			public const int TextAppearance_MaterialComponents_Overline = 2131231084;
 			
-			// aapt resource value: 0x7f0c01a1
-			public const int TextAppearance_MaterialComponents_Subtitle1 = 2131493281;
+			// aapt resource value: 0x7f0801a2
+			public const int TextAppearance_MaterialComponents_Subtitle1 = 2131231138;
 			
-			// aapt resource value: 0x7f0c016c
-			public const int TextAppearance_MaterialComponents_Subtitle2 = 2131493228;
+			// aapt resource value: 0x7f08016d
+			public const int TextAppearance_MaterialComponents_Subtitle2 = 2131231085;
 			
-			// aapt resource value: 0x7f0c01a2
-			public const int TextAppearance_MaterialComponents_Tab = 2131493282;
+			// aapt resource value: 0x7f0801a3
+			public const int TextAppearance_MaterialComponents_Tab = 2131231139;
 			
-			// aapt resource value: 0x7f0c0000
-			public const int TextAppearance_MediaRouter_PrimaryText = 2131492864;
+			// aapt resource value: 0x7f080001
+			public const int TextAppearance_MediaRouter_PrimaryText = 2131230721;
 			
-			// aapt resource value: 0x7f0c0001
-			public const int TextAppearance_MediaRouter_SecondaryText = 2131492865;
+			// aapt resource value: 0x7f080002
+			public const int TextAppearance_MediaRouter_SecondaryText = 2131230722;
 			
-			// aapt resource value: 0x7f0c0002
-			public const int TextAppearance_MediaRouter_Title = 2131492866;
+			// aapt resource value: 0x7f080003
+			public const int TextAppearance_MediaRouter_Title = 2131230723;
 			
-			// aapt resource value: 0x7f0c0101
-			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131493121;
+			// aapt resource value: 0x7f080102
+			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131230978;
 			
-			// aapt resource value: 0x7f0c0102
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131493122;
+			// aapt resource value: 0x7f080103
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131230979;
 			
-			// aapt resource value: 0x7f0c0103
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131493123;
+			// aapt resource value: 0x7f080104
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131230980;
 			
-			// aapt resource value: 0x7f0c0104
-			public const int Theme_AppCompat = 2131493124;
+			// aapt resource value: 0x7f080105
+			public const int Theme_AppCompat = 2131230981;
 			
-			// aapt resource value: 0x7f0c0105
-			public const int Theme_AppCompat_CompactMenu = 2131493125;
+			// aapt resource value: 0x7f080106
+			public const int Theme_AppCompat_CompactMenu = 2131230982;
 			
-			// aapt resource value: 0x7f0c0013
-			public const int Theme_AppCompat_DayNight = 2131492883;
+			// aapt resource value: 0x7f080014
+			public const int Theme_AppCompat_DayNight = 2131230740;
 			
-			// aapt resource value: 0x7f0c0014
-			public const int Theme_AppCompat_DayNight_DarkActionBar = 2131492884;
+			// aapt resource value: 0x7f080015
+			public const int Theme_AppCompat_DayNight_DarkActionBar = 2131230741;
 			
-			// aapt resource value: 0x7f0c0015
-			public const int Theme_AppCompat_DayNight_Dialog = 2131492885;
+			// aapt resource value: 0x7f080016
+			public const int Theme_AppCompat_DayNight_Dialog = 2131230742;
 			
-			// aapt resource value: 0x7f0c0016
-			public const int Theme_AppCompat_DayNight_Dialog_Alert = 2131492886;
+			// aapt resource value: 0x7f080017
+			public const int Theme_AppCompat_DayNight_Dialog_Alert = 2131230743;
 			
-			// aapt resource value: 0x7f0c0017
-			public const int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131492887;
+			// aapt resource value: 0x7f080018
+			public const int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131230744;
 			
-			// aapt resource value: 0x7f0c0018
-			public const int Theme_AppCompat_DayNight_DialogWhenLarge = 2131492888;
+			// aapt resource value: 0x7f080019
+			public const int Theme_AppCompat_DayNight_DialogWhenLarge = 2131230745;
 			
-			// aapt resource value: 0x7f0c0019
-			public const int Theme_AppCompat_DayNight_NoActionBar = 2131492889;
+			// aapt resource value: 0x7f08001a
+			public const int Theme_AppCompat_DayNight_NoActionBar = 2131230746;
 			
-			// aapt resource value: 0x7f0c0106
-			public const int Theme_AppCompat_Dialog = 2131493126;
+			// aapt resource value: 0x7f080107
+			public const int Theme_AppCompat_Dialog = 2131230983;
 			
-			// aapt resource value: 0x7f0c0107
-			public const int Theme_AppCompat_Dialog_Alert = 2131493127;
+			// aapt resource value: 0x7f080108
+			public const int Theme_AppCompat_Dialog_Alert = 2131230984;
 			
-			// aapt resource value: 0x7f0c0108
-			public const int Theme_AppCompat_Dialog_MinWidth = 2131493128;
+			// aapt resource value: 0x7f080109
+			public const int Theme_AppCompat_Dialog_MinWidth = 2131230985;
 			
-			// aapt resource value: 0x7f0c0109
-			public const int Theme_AppCompat_DialogWhenLarge = 2131493129;
+			// aapt resource value: 0x7f08010a
+			public const int Theme_AppCompat_DialogWhenLarge = 2131230986;
 			
-			// aapt resource value: 0x7f0c010a
-			public const int Theme_AppCompat_Light = 2131493130;
+			// aapt resource value: 0x7f08010b
+			public const int Theme_AppCompat_Light = 2131230987;
 			
-			// aapt resource value: 0x7f0c010b
-			public const int Theme_AppCompat_Light_DarkActionBar = 2131493131;
+			// aapt resource value: 0x7f08010c
+			public const int Theme_AppCompat_Light_DarkActionBar = 2131230988;
 			
-			// aapt resource value: 0x7f0c010c
-			public const int Theme_AppCompat_Light_Dialog = 2131493132;
+			// aapt resource value: 0x7f08010d
+			public const int Theme_AppCompat_Light_Dialog = 2131230989;
 			
-			// aapt resource value: 0x7f0c010d
-			public const int Theme_AppCompat_Light_Dialog_Alert = 2131493133;
+			// aapt resource value: 0x7f08010e
+			public const int Theme_AppCompat_Light_Dialog_Alert = 2131230990;
 			
-			// aapt resource value: 0x7f0c010e
-			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131493134;
+			// aapt resource value: 0x7f08010f
+			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131230991;
 			
-			// aapt resource value: 0x7f0c010f
-			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131493135;
+			// aapt resource value: 0x7f080110
+			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131230992;
 			
-			// aapt resource value: 0x7f0c0110
-			public const int Theme_AppCompat_Light_NoActionBar = 2131493136;
+			// aapt resource value: 0x7f080111
+			public const int Theme_AppCompat_Light_NoActionBar = 2131230993;
 			
-			// aapt resource value: 0x7f0c0111
-			public const int Theme_AppCompat_NoActionBar = 2131493137;
+			// aapt resource value: 0x7f080112
+			public const int Theme_AppCompat_NoActionBar = 2131230994;
 			
-			// aapt resource value: 0x7f0c01a3
-			public const int Theme_Design = 2131493283;
+			// aapt resource value: 0x7f0801a4
+			public const int Theme_Design = 2131231140;
 			
-			// aapt resource value: 0x7f0c01a4
-			public const int Theme_Design_BottomSheetDialog = 2131493284;
+			// aapt resource value: 0x7f0801a5
+			public const int Theme_Design_BottomSheetDialog = 2131231141;
 			
-			// aapt resource value: 0x7f0c01a5
-			public const int Theme_Design_Light = 2131493285;
+			// aapt resource value: 0x7f0801a6
+			public const int Theme_Design_Light = 2131231142;
 			
-			// aapt resource value: 0x7f0c01a6
-			public const int Theme_Design_Light_BottomSheetDialog = 2131493286;
+			// aapt resource value: 0x7f0801a7
+			public const int Theme_Design_Light_BottomSheetDialog = 2131231143;
 			
-			// aapt resource value: 0x7f0c01a7
-			public const int Theme_Design_Light_NoActionBar = 2131493287;
+			// aapt resource value: 0x7f0801a8
+			public const int Theme_Design_Light_NoActionBar = 2131231144;
 			
-			// aapt resource value: 0x7f0c01a8
-			public const int Theme_Design_NoActionBar = 2131493288;
+			// aapt resource value: 0x7f0801a9
+			public const int Theme_Design_NoActionBar = 2131231145;
 			
-			// aapt resource value: 0x7f0c01a9
-			public const int Theme_MaterialComponents = 2131493289;
+			// aapt resource value: 0x7f0801aa
+			public const int Theme_MaterialComponents = 2131231146;
 			
-			// aapt resource value: 0x7f0c01aa
-			public const int Theme_MaterialComponents_BottomSheetDialog = 2131493290;
+			// aapt resource value: 0x7f0801ab
+			public const int Theme_MaterialComponents_BottomSheetDialog = 2131231147;
 			
-			// aapt resource value: 0x7f0c01ab
-			public const int Theme_MaterialComponents_Bridge = 2131493291;
+			// aapt resource value: 0x7f0801ac
+			public const int Theme_MaterialComponents_Bridge = 2131231148;
 			
-			// aapt resource value: 0x7f0c01ac
-			public const int Theme_MaterialComponents_CompactMenu = 2131493292;
+			// aapt resource value: 0x7f0801ad
+			public const int Theme_MaterialComponents_CompactMenu = 2131231149;
 			
-			// aapt resource value: 0x7f0c01ad
-			public const int Theme_MaterialComponents_Dialog = 2131493293;
+			// aapt resource value: 0x7f0801ae
+			public const int Theme_MaterialComponents_Dialog = 2131231150;
 			
-			// aapt resource value: 0x7f0c01ae
-			public const int Theme_MaterialComponents_Dialog_Alert = 2131493294;
+			// aapt resource value: 0x7f0801af
+			public const int Theme_MaterialComponents_Dialog_Alert = 2131231151;
 			
-			// aapt resource value: 0x7f0c01af
-			public const int Theme_MaterialComponents_Dialog_MinWidth = 2131493295;
+			// aapt resource value: 0x7f0801b0
+			public const int Theme_MaterialComponents_Dialog_MinWidth = 2131231152;
 			
-			// aapt resource value: 0x7f0c01b0
-			public const int Theme_MaterialComponents_DialogWhenLarge = 2131493296;
+			// aapt resource value: 0x7f0801b1
+			public const int Theme_MaterialComponents_DialogWhenLarge = 2131231153;
 			
-			// aapt resource value: 0x7f0c01b1
-			public const int Theme_MaterialComponents_Light = 2131493297;
+			// aapt resource value: 0x7f0801b2
+			public const int Theme_MaterialComponents_Light = 2131231154;
 			
-			// aapt resource value: 0x7f0c01b2
-			public const int Theme_MaterialComponents_Light_BottomSheetDialog = 2131493298;
+			// aapt resource value: 0x7f0801b3
+			public const int Theme_MaterialComponents_Light_BottomSheetDialog = 2131231155;
 			
-			// aapt resource value: 0x7f0c01b3
-			public const int Theme_MaterialComponents_Light_Bridge = 2131493299;
+			// aapt resource value: 0x7f0801b4
+			public const int Theme_MaterialComponents_Light_Bridge = 2131231156;
 			
-			// aapt resource value: 0x7f0c01b4
-			public const int Theme_MaterialComponents_Light_DarkActionBar = 2131493300;
+			// aapt resource value: 0x7f0801b5
+			public const int Theme_MaterialComponents_Light_DarkActionBar = 2131231157;
 			
-			// aapt resource value: 0x7f0c01b5
-			public const int Theme_MaterialComponents_Light_DarkActionBar_Bridge = 2131493301;
+			// aapt resource value: 0x7f0801b6
+			public const int Theme_MaterialComponents_Light_DarkActionBar_Bridge = 2131231158;
 			
-			// aapt resource value: 0x7f0c01b6
-			public const int Theme_MaterialComponents_Light_Dialog = 2131493302;
+			// aapt resource value: 0x7f0801b7
+			public const int Theme_MaterialComponents_Light_Dialog = 2131231159;
 			
-			// aapt resource value: 0x7f0c01b7
-			public const int Theme_MaterialComponents_Light_Dialog_Alert = 2131493303;
+			// aapt resource value: 0x7f0801b8
+			public const int Theme_MaterialComponents_Light_Dialog_Alert = 2131231160;
 			
-			// aapt resource value: 0x7f0c01b8
-			public const int Theme_MaterialComponents_Light_Dialog_MinWidth = 2131493304;
+			// aapt resource value: 0x7f0801b9
+			public const int Theme_MaterialComponents_Light_Dialog_MinWidth = 2131231161;
 			
-			// aapt resource value: 0x7f0c01b9
-			public const int Theme_MaterialComponents_Light_DialogWhenLarge = 2131493305;
+			// aapt resource value: 0x7f0801ba
+			public const int Theme_MaterialComponents_Light_DialogWhenLarge = 2131231162;
 			
-			// aapt resource value: 0x7f0c01ba
-			public const int Theme_MaterialComponents_Light_NoActionBar = 2131493306;
+			// aapt resource value: 0x7f0801bb
+			public const int Theme_MaterialComponents_Light_NoActionBar = 2131231163;
 			
-			// aapt resource value: 0x7f0c01bb
-			public const int Theme_MaterialComponents_Light_NoActionBar_Bridge = 2131493307;
+			// aapt resource value: 0x7f0801bc
+			public const int Theme_MaterialComponents_Light_NoActionBar_Bridge = 2131231164;
 			
-			// aapt resource value: 0x7f0c01bc
-			public const int Theme_MaterialComponents_NoActionBar = 2131493308;
+			// aapt resource value: 0x7f0801bd
+			public const int Theme_MaterialComponents_NoActionBar = 2131231165;
 			
-			// aapt resource value: 0x7f0c01bd
-			public const int Theme_MaterialComponents_NoActionBar_Bridge = 2131493309;
+			// aapt resource value: 0x7f0801be
+			public const int Theme_MaterialComponents_NoActionBar_Bridge = 2131231166;
 			
-			// aapt resource value: 0x7f0c0003
-			public const int Theme_MediaRouter = 2131492867;
+			// aapt resource value: 0x7f080004
+			public const int Theme_MediaRouter = 2131230724;
 			
-			// aapt resource value: 0x7f0c0004
-			public const int Theme_MediaRouter_Light = 2131492868;
+			// aapt resource value: 0x7f080005
+			public const int Theme_MediaRouter_Light = 2131230725;
 			
-			// aapt resource value: 0x7f0c0005
-			public const int Theme_MediaRouter_Light_DarkControlPanel = 2131492869;
+			// aapt resource value: 0x7f080006
+			public const int Theme_MediaRouter_Light_DarkControlPanel = 2131230726;
 			
-			// aapt resource value: 0x7f0c0006
-			public const int Theme_MediaRouter_LightControlPanel = 2131492870;
+			// aapt resource value: 0x7f080007
+			public const int Theme_MediaRouter_LightControlPanel = 2131230727;
 			
-			// aapt resource value: 0x7f0c01ff
-			public const int Theme_Splash = 2131493375;
+			// aapt resource value: 0x7f080200
+			public const int Theme_Splash = 2131231232;
 			
-			// aapt resource value: 0x7f0c0112
-			public const int ThemeOverlay_AppCompat = 2131493138;
+			// aapt resource value: 0x7f080113
+			public const int ThemeOverlay_AppCompat = 2131230995;
 			
-			// aapt resource value: 0x7f0c0113
-			public const int ThemeOverlay_AppCompat_ActionBar = 2131493139;
+			// aapt resource value: 0x7f080114
+			public const int ThemeOverlay_AppCompat_ActionBar = 2131230996;
 			
-			// aapt resource value: 0x7f0c0114
-			public const int ThemeOverlay_AppCompat_Dark = 2131493140;
+			// aapt resource value: 0x7f080115
+			public const int ThemeOverlay_AppCompat_Dark = 2131230997;
 			
-			// aapt resource value: 0x7f0c0115
-			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131493141;
+			// aapt resource value: 0x7f080116
+			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131230998;
 			
-			// aapt resource value: 0x7f0c0116
-			public const int ThemeOverlay_AppCompat_Dialog = 2131493142;
+			// aapt resource value: 0x7f080117
+			public const int ThemeOverlay_AppCompat_Dialog = 2131230999;
 			
-			// aapt resource value: 0x7f0c0117
-			public const int ThemeOverlay_AppCompat_Dialog_Alert = 2131493143;
+			// aapt resource value: 0x7f080118
+			public const int ThemeOverlay_AppCompat_Dialog_Alert = 2131231000;
 			
-			// aapt resource value: 0x7f0c0118
-			public const int ThemeOverlay_AppCompat_Light = 2131493144;
+			// aapt resource value: 0x7f080119
+			public const int ThemeOverlay_AppCompat_Light = 2131231001;
 			
-			// aapt resource value: 0x7f0c01be
-			public const int ThemeOverlay_MaterialComponents = 2131493310;
+			// aapt resource value: 0x7f0801bf
+			public const int ThemeOverlay_MaterialComponents = 2131231167;
 			
-			// aapt resource value: 0x7f0c01bf
-			public const int ThemeOverlay_MaterialComponents_ActionBar = 2131493311;
+			// aapt resource value: 0x7f0801c0
+			public const int ThemeOverlay_MaterialComponents_ActionBar = 2131231168;
 			
-			// aapt resource value: 0x7f0c01c0
-			public const int ThemeOverlay_MaterialComponents_Dark = 2131493312;
+			// aapt resource value: 0x7f0801c1
+			public const int ThemeOverlay_MaterialComponents_Dark = 2131231169;
 			
-			// aapt resource value: 0x7f0c01c1
-			public const int ThemeOverlay_MaterialComponents_Dark_ActionBar = 2131493313;
+			// aapt resource value: 0x7f0801c2
+			public const int ThemeOverlay_MaterialComponents_Dark_ActionBar = 2131231170;
 			
-			// aapt resource value: 0x7f0c01c2
-			public const int ThemeOverlay_MaterialComponents_Dialog = 2131493314;
+			// aapt resource value: 0x7f0801c3
+			public const int ThemeOverlay_MaterialComponents_Dialog = 2131231171;
 			
-			// aapt resource value: 0x7f0c01c3
-			public const int ThemeOverlay_MaterialComponents_Dialog_Alert = 2131493315;
+			// aapt resource value: 0x7f0801c4
+			public const int ThemeOverlay_MaterialComponents_Dialog_Alert = 2131231172;
 			
-			// aapt resource value: 0x7f0c01c4
-			public const int ThemeOverlay_MaterialComponents_Light = 2131493316;
+			// aapt resource value: 0x7f0801c5
+			public const int ThemeOverlay_MaterialComponents_Light = 2131231173;
 			
-			// aapt resource value: 0x7f0c01c5
-			public const int ThemeOverlay_MaterialComponents_TextInputEditText = 2131493317;
+			// aapt resource value: 0x7f0801c6
+			public const int ThemeOverlay_MaterialComponents_TextInputEditText = 2131231174;
 			
-			// aapt resource value: 0x7f0c01c6
-			public const int ThemeOverlay_MaterialComponents_TextInputEditText_FilledBox = 2131493318;
+			// aapt resource value: 0x7f0801c7
+			public const int ThemeOverlay_MaterialComponents_TextInputEditText_FilledBox = 2131231175;
 			
-			// aapt resource value: 0x7f0c01c7
-			public const int ThemeOverlay_MaterialComponents_TextInputEditText_FilledBox_Dense = 2131493319;
+			// aapt resource value: 0x7f0801c8
+			public const int ThemeOverlay_MaterialComponents_TextInputEditText_FilledBox_Dense = 2131231176;
 			
-			// aapt resource value: 0x7f0c01c8
-			public const int ThemeOverlay_MaterialComponents_TextInputEditText_OutlinedBox = 2131493320;
+			// aapt resource value: 0x7f0801c9
+			public const int ThemeOverlay_MaterialComponents_TextInputEditText_OutlinedBox = 2131231177;
 			
-			// aapt resource value: 0x7f0c01c9
-			public const int ThemeOverlay_MaterialComponents_TextInputEditText_OutlinedBox_Dense = 2131493321;
+			// aapt resource value: 0x7f0801ca
+			public const int ThemeOverlay_MaterialComponents_TextInputEditText_OutlinedBox_Dense = 2131231178;
 			
-			// aapt resource value: 0x7f0c0007
-			public const int ThemeOverlay_MediaRouter_Dark = 2131492871;
+			// aapt resource value: 0x7f080008
+			public const int ThemeOverlay_MediaRouter_Dark = 2131230728;
 			
-			// aapt resource value: 0x7f0c0008
-			public const int ThemeOverlay_MediaRouter_Light = 2131492872;
+			// aapt resource value: 0x7f080009
+			public const int ThemeOverlay_MediaRouter_Light = 2131230729;
 			
-			// aapt resource value: 0x7f0c0119
-			public const int Widget_AppCompat_ActionBar = 2131493145;
+			// aapt resource value: 0x7f08011a
+			public const int Widget_AppCompat_ActionBar = 2131231002;
 			
-			// aapt resource value: 0x7f0c011a
-			public const int Widget_AppCompat_ActionBar_Solid = 2131493146;
+			// aapt resource value: 0x7f08011b
+			public const int Widget_AppCompat_ActionBar_Solid = 2131231003;
 			
-			// aapt resource value: 0x7f0c011b
-			public const int Widget_AppCompat_ActionBar_TabBar = 2131493147;
+			// aapt resource value: 0x7f08011c
+			public const int Widget_AppCompat_ActionBar_TabBar = 2131231004;
 			
-			// aapt resource value: 0x7f0c011c
-			public const int Widget_AppCompat_ActionBar_TabText = 2131493148;
+			// aapt resource value: 0x7f08011d
+			public const int Widget_AppCompat_ActionBar_TabText = 2131231005;
 			
-			// aapt resource value: 0x7f0c011d
-			public const int Widget_AppCompat_ActionBar_TabView = 2131493149;
+			// aapt resource value: 0x7f08011e
+			public const int Widget_AppCompat_ActionBar_TabView = 2131231006;
 			
-			// aapt resource value: 0x7f0c011e
-			public const int Widget_AppCompat_ActionButton = 2131493150;
+			// aapt resource value: 0x7f08011f
+			public const int Widget_AppCompat_ActionButton = 2131231007;
 			
-			// aapt resource value: 0x7f0c011f
-			public const int Widget_AppCompat_ActionButton_CloseMode = 2131493151;
+			// aapt resource value: 0x7f080120
+			public const int Widget_AppCompat_ActionButton_CloseMode = 2131231008;
 			
-			// aapt resource value: 0x7f0c0120
-			public const int Widget_AppCompat_ActionButton_Overflow = 2131493152;
+			// aapt resource value: 0x7f080121
+			public const int Widget_AppCompat_ActionButton_Overflow = 2131231009;
 			
-			// aapt resource value: 0x7f0c0121
-			public const int Widget_AppCompat_ActionMode = 2131493153;
+			// aapt resource value: 0x7f080122
+			public const int Widget_AppCompat_ActionMode = 2131231010;
 			
-			// aapt resource value: 0x7f0c0122
-			public const int Widget_AppCompat_ActivityChooserView = 2131493154;
+			// aapt resource value: 0x7f080123
+			public const int Widget_AppCompat_ActivityChooserView = 2131231011;
 			
-			// aapt resource value: 0x7f0c0123
-			public const int Widget_AppCompat_AutoCompleteTextView = 2131493155;
+			// aapt resource value: 0x7f080124
+			public const int Widget_AppCompat_AutoCompleteTextView = 2131231012;
 			
-			// aapt resource value: 0x7f0c0124
-			public const int Widget_AppCompat_Button = 2131493156;
+			// aapt resource value: 0x7f080125
+			public const int Widget_AppCompat_Button = 2131231013;
 			
-			// aapt resource value: 0x7f0c0125
-			public const int Widget_AppCompat_Button_Borderless = 2131493157;
+			// aapt resource value: 0x7f080126
+			public const int Widget_AppCompat_Button_Borderless = 2131231014;
 			
-			// aapt resource value: 0x7f0c0126
-			public const int Widget_AppCompat_Button_Borderless_Colored = 2131493158;
+			// aapt resource value: 0x7f080127
+			public const int Widget_AppCompat_Button_Borderless_Colored = 2131231015;
 			
-			// aapt resource value: 0x7f0c0127
-			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131493159;
+			// aapt resource value: 0x7f080128
+			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131231016;
 			
-			// aapt resource value: 0x7f0c0128
-			public const int Widget_AppCompat_Button_Colored = 2131493160;
+			// aapt resource value: 0x7f080129
+			public const int Widget_AppCompat_Button_Colored = 2131231017;
 			
-			// aapt resource value: 0x7f0c0129
-			public const int Widget_AppCompat_Button_Small = 2131493161;
+			// aapt resource value: 0x7f08012a
+			public const int Widget_AppCompat_Button_Small = 2131231018;
 			
-			// aapt resource value: 0x7f0c012a
-			public const int Widget_AppCompat_ButtonBar = 2131493162;
+			// aapt resource value: 0x7f08012b
+			public const int Widget_AppCompat_ButtonBar = 2131231019;
 			
-			// aapt resource value: 0x7f0c012b
-			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131493163;
+			// aapt resource value: 0x7f08012c
+			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131231020;
 			
-			// aapt resource value: 0x7f0c012c
-			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131493164;
+			// aapt resource value: 0x7f08012d
+			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131231021;
 			
-			// aapt resource value: 0x7f0c012d
-			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131493165;
+			// aapt resource value: 0x7f08012e
+			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131231022;
 			
-			// aapt resource value: 0x7f0c012e
-			public const int Widget_AppCompat_CompoundButton_Switch = 2131493166;
+			// aapt resource value: 0x7f08012f
+			public const int Widget_AppCompat_CompoundButton_Switch = 2131231023;
 			
-			// aapt resource value: 0x7f0c012f
-			public const int Widget_AppCompat_DrawerArrowToggle = 2131493167;
+			// aapt resource value: 0x7f080130
+			public const int Widget_AppCompat_DrawerArrowToggle = 2131231024;
 			
-			// aapt resource value: 0x7f0c0130
-			public const int Widget_AppCompat_DropDownItem_Spinner = 2131493168;
+			// aapt resource value: 0x7f080131
+			public const int Widget_AppCompat_DropDownItem_Spinner = 2131231025;
 			
-			// aapt resource value: 0x7f0c0131
-			public const int Widget_AppCompat_EditText = 2131493169;
+			// aapt resource value: 0x7f080132
+			public const int Widget_AppCompat_EditText = 2131231026;
 			
-			// aapt resource value: 0x7f0c0132
-			public const int Widget_AppCompat_ImageButton = 2131493170;
+			// aapt resource value: 0x7f080133
+			public const int Widget_AppCompat_ImageButton = 2131231027;
 			
-			// aapt resource value: 0x7f0c0133
-			public const int Widget_AppCompat_Light_ActionBar = 2131493171;
+			// aapt resource value: 0x7f080134
+			public const int Widget_AppCompat_Light_ActionBar = 2131231028;
 			
-			// aapt resource value: 0x7f0c0134
-			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131493172;
+			// aapt resource value: 0x7f080135
+			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131231029;
 			
-			// aapt resource value: 0x7f0c0135
-			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131493173;
+			// aapt resource value: 0x7f080136
+			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131231030;
 			
-			// aapt resource value: 0x7f0c0136
-			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131493174;
+			// aapt resource value: 0x7f080137
+			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131231031;
 			
-			// aapt resource value: 0x7f0c0137
-			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131493175;
+			// aapt resource value: 0x7f080138
+			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131231032;
 			
-			// aapt resource value: 0x7f0c0138
-			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131493176;
+			// aapt resource value: 0x7f080139
+			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131231033;
 			
-			// aapt resource value: 0x7f0c0139
-			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131493177;
+			// aapt resource value: 0x7f08013a
+			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131231034;
 			
-			// aapt resource value: 0x7f0c013a
-			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131493178;
+			// aapt resource value: 0x7f08013b
+			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131231035;
 			
-			// aapt resource value: 0x7f0c013b
-			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131493179;
+			// aapt resource value: 0x7f08013c
+			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131231036;
 			
-			// aapt resource value: 0x7f0c013c
-			public const int Widget_AppCompat_Light_ActionButton = 2131493180;
+			// aapt resource value: 0x7f08013d
+			public const int Widget_AppCompat_Light_ActionButton = 2131231037;
 			
-			// aapt resource value: 0x7f0c013d
-			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131493181;
+			// aapt resource value: 0x7f08013e
+			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131231038;
 			
-			// aapt resource value: 0x7f0c013e
-			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131493182;
+			// aapt resource value: 0x7f08013f
+			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131231039;
 			
-			// aapt resource value: 0x7f0c013f
-			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131493183;
+			// aapt resource value: 0x7f080140
+			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131231040;
 			
-			// aapt resource value: 0x7f0c0140
-			public const int Widget_AppCompat_Light_ActivityChooserView = 2131493184;
+			// aapt resource value: 0x7f080141
+			public const int Widget_AppCompat_Light_ActivityChooserView = 2131231041;
 			
-			// aapt resource value: 0x7f0c0141
-			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131493185;
+			// aapt resource value: 0x7f080142
+			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131231042;
 			
-			// aapt resource value: 0x7f0c0142
-			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131493186;
+			// aapt resource value: 0x7f080143
+			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131231043;
 			
-			// aapt resource value: 0x7f0c0143
-			public const int Widget_AppCompat_Light_ListPopupWindow = 2131493187;
+			// aapt resource value: 0x7f080144
+			public const int Widget_AppCompat_Light_ListPopupWindow = 2131231044;
 			
-			// aapt resource value: 0x7f0c0144
-			public const int Widget_AppCompat_Light_ListView_DropDown = 2131493188;
+			// aapt resource value: 0x7f080145
+			public const int Widget_AppCompat_Light_ListView_DropDown = 2131231045;
 			
-			// aapt resource value: 0x7f0c0145
-			public const int Widget_AppCompat_Light_PopupMenu = 2131493189;
+			// aapt resource value: 0x7f080146
+			public const int Widget_AppCompat_Light_PopupMenu = 2131231046;
 			
-			// aapt resource value: 0x7f0c0146
-			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131493190;
+			// aapt resource value: 0x7f080147
+			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131231047;
 			
-			// aapt resource value: 0x7f0c0147
-			public const int Widget_AppCompat_Light_SearchView = 2131493191;
+			// aapt resource value: 0x7f080148
+			public const int Widget_AppCompat_Light_SearchView = 2131231048;
 			
-			// aapt resource value: 0x7f0c0148
-			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131493192;
+			// aapt resource value: 0x7f080149
+			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131231049;
 			
-			// aapt resource value: 0x7f0c0149
-			public const int Widget_AppCompat_ListMenuView = 2131493193;
+			// aapt resource value: 0x7f08014a
+			public const int Widget_AppCompat_ListMenuView = 2131231050;
 			
-			// aapt resource value: 0x7f0c014a
-			public const int Widget_AppCompat_ListPopupWindow = 2131493194;
+			// aapt resource value: 0x7f08014b
+			public const int Widget_AppCompat_ListPopupWindow = 2131231051;
 			
-			// aapt resource value: 0x7f0c014b
-			public const int Widget_AppCompat_ListView = 2131493195;
+			// aapt resource value: 0x7f08014c
+			public const int Widget_AppCompat_ListView = 2131231052;
 			
-			// aapt resource value: 0x7f0c014c
-			public const int Widget_AppCompat_ListView_DropDown = 2131493196;
+			// aapt resource value: 0x7f08014d
+			public const int Widget_AppCompat_ListView_DropDown = 2131231053;
 			
-			// aapt resource value: 0x7f0c014d
-			public const int Widget_AppCompat_ListView_Menu = 2131493197;
+			// aapt resource value: 0x7f08014e
+			public const int Widget_AppCompat_ListView_Menu = 2131231054;
 			
-			// aapt resource value: 0x7f0c014e
-			public const int Widget_AppCompat_PopupMenu = 2131493198;
+			// aapt resource value: 0x7f08014f
+			public const int Widget_AppCompat_PopupMenu = 2131231055;
 			
-			// aapt resource value: 0x7f0c014f
-			public const int Widget_AppCompat_PopupMenu_Overflow = 2131493199;
+			// aapt resource value: 0x7f080150
+			public const int Widget_AppCompat_PopupMenu_Overflow = 2131231056;
 			
-			// aapt resource value: 0x7f0c0150
-			public const int Widget_AppCompat_PopupWindow = 2131493200;
+			// aapt resource value: 0x7f080151
+			public const int Widget_AppCompat_PopupWindow = 2131231057;
 			
-			// aapt resource value: 0x7f0c0151
-			public const int Widget_AppCompat_ProgressBar = 2131493201;
+			// aapt resource value: 0x7f080152
+			public const int Widget_AppCompat_ProgressBar = 2131231058;
 			
-			// aapt resource value: 0x7f0c0152
-			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131493202;
+			// aapt resource value: 0x7f080153
+			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131231059;
 			
-			// aapt resource value: 0x7f0c0153
-			public const int Widget_AppCompat_RatingBar = 2131493203;
+			// aapt resource value: 0x7f080154
+			public const int Widget_AppCompat_RatingBar = 2131231060;
 			
-			// aapt resource value: 0x7f0c0154
-			public const int Widget_AppCompat_RatingBar_Indicator = 2131493204;
+			// aapt resource value: 0x7f080155
+			public const int Widget_AppCompat_RatingBar_Indicator = 2131231061;
 			
-			// aapt resource value: 0x7f0c0155
-			public const int Widget_AppCompat_RatingBar_Small = 2131493205;
+			// aapt resource value: 0x7f080156
+			public const int Widget_AppCompat_RatingBar_Small = 2131231062;
 			
-			// aapt resource value: 0x7f0c0156
-			public const int Widget_AppCompat_SearchView = 2131493206;
+			// aapt resource value: 0x7f080157
+			public const int Widget_AppCompat_SearchView = 2131231063;
 			
-			// aapt resource value: 0x7f0c0157
-			public const int Widget_AppCompat_SearchView_ActionBar = 2131493207;
+			// aapt resource value: 0x7f080158
+			public const int Widget_AppCompat_SearchView_ActionBar = 2131231064;
 			
-			// aapt resource value: 0x7f0c0158
-			public const int Widget_AppCompat_SeekBar = 2131493208;
+			// aapt resource value: 0x7f080159
+			public const int Widget_AppCompat_SeekBar = 2131231065;
 			
-			// aapt resource value: 0x7f0c0159
-			public const int Widget_AppCompat_SeekBar_Discrete = 2131493209;
+			// aapt resource value: 0x7f08015a
+			public const int Widget_AppCompat_SeekBar_Discrete = 2131231066;
 			
-			// aapt resource value: 0x7f0c015a
-			public const int Widget_AppCompat_Spinner = 2131493210;
+			// aapt resource value: 0x7f08015b
+			public const int Widget_AppCompat_Spinner = 2131231067;
 			
-			// aapt resource value: 0x7f0c015b
-			public const int Widget_AppCompat_Spinner_DropDown = 2131493211;
+			// aapt resource value: 0x7f08015c
+			public const int Widget_AppCompat_Spinner_DropDown = 2131231068;
 			
-			// aapt resource value: 0x7f0c015c
-			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131493212;
+			// aapt resource value: 0x7f08015d
+			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131231069;
 			
-			// aapt resource value: 0x7f0c015d
-			public const int Widget_AppCompat_Spinner_Underlined = 2131493213;
+			// aapt resource value: 0x7f08015e
+			public const int Widget_AppCompat_Spinner_Underlined = 2131231070;
 			
-			// aapt resource value: 0x7f0c015e
-			public const int Widget_AppCompat_TextView_SpinnerItem = 2131493214;
+			// aapt resource value: 0x7f08015f
+			public const int Widget_AppCompat_TextView_SpinnerItem = 2131231071;
 			
-			// aapt resource value: 0x7f0c015f
-			public const int Widget_AppCompat_Toolbar = 2131493215;
+			// aapt resource value: 0x7f080160
+			public const int Widget_AppCompat_Toolbar = 2131231072;
 			
-			// aapt resource value: 0x7f0c0160
-			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131493216;
+			// aapt resource value: 0x7f080161
+			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131231073;
 			
-			// aapt resource value: 0x7f0c01fc
-			public const int Widget_Compat_NotificationActionContainer = 2131493372;
+			// aapt resource value: 0x7f0801fd
+			public const int Widget_Compat_NotificationActionContainer = 2131231229;
 			
-			// aapt resource value: 0x7f0c01fd
-			public const int Widget_Compat_NotificationActionText = 2131493373;
+			// aapt resource value: 0x7f0801fe
+			public const int Widget_Compat_NotificationActionText = 2131231230;
 			
-			// aapt resource value: 0x7f0c01ca
-			public const int Widget_Design_AppBarLayout = 2131493322;
+			// aapt resource value: 0x7f0801cb
+			public const int Widget_Design_AppBarLayout = 2131231179;
 			
-			// aapt resource value: 0x7f0c01cb
-			public const int Widget_Design_BottomNavigationView = 2131493323;
+			// aapt resource value: 0x7f0801cc
+			public const int Widget_Design_BottomNavigationView = 2131231180;
 			
-			// aapt resource value: 0x7f0c01cc
-			public const int Widget_Design_BottomSheet_Modal = 2131493324;
+			// aapt resource value: 0x7f0801cd
+			public const int Widget_Design_BottomSheet_Modal = 2131231181;
 			
-			// aapt resource value: 0x7f0c01cd
-			public const int Widget_Design_CollapsingToolbar = 2131493325;
+			// aapt resource value: 0x7f0801ce
+			public const int Widget_Design_CollapsingToolbar = 2131231182;
 			
-			// aapt resource value: 0x7f0c01ce
-			public const int Widget_Design_FloatingActionButton = 2131493326;
+			// aapt resource value: 0x7f0801cf
+			public const int Widget_Design_FloatingActionButton = 2131231183;
 			
-			// aapt resource value: 0x7f0c01cf
-			public const int Widget_Design_NavigationView = 2131493327;
+			// aapt resource value: 0x7f0801d0
+			public const int Widget_Design_NavigationView = 2131231184;
 			
-			// aapt resource value: 0x7f0c01d0
-			public const int Widget_Design_ScrimInsetsFrameLayout = 2131493328;
+			// aapt resource value: 0x7f0801d1
+			public const int Widget_Design_ScrimInsetsFrameLayout = 2131231185;
 			
-			// aapt resource value: 0x7f0c01d1
-			public const int Widget_Design_Snackbar = 2131493329;
+			// aapt resource value: 0x7f0801d2
+			public const int Widget_Design_Snackbar = 2131231186;
 			
-			// aapt resource value: 0x7f0c0166
-			public const int Widget_Design_TabLayout = 2131493222;
+			// aapt resource value: 0x7f080167
+			public const int Widget_Design_TabLayout = 2131231079;
 			
-			// aapt resource value: 0x7f0c01d2
-			public const int Widget_Design_TextInputLayout = 2131493330;
+			// aapt resource value: 0x7f0801d3
+			public const int Widget_Design_TextInputLayout = 2131231187;
 			
-			// aapt resource value: 0x7f0c01d3
-			public const int Widget_MaterialComponents_BottomAppBar = 2131493331;
+			// aapt resource value: 0x7f0801d4
+			public const int Widget_MaterialComponents_BottomAppBar = 2131231188;
 			
-			// aapt resource value: 0x7f0c01d4
-			public const int Widget_MaterialComponents_BottomAppBar_Colored = 2131493332;
+			// aapt resource value: 0x7f0801d5
+			public const int Widget_MaterialComponents_BottomAppBar_Colored = 2131231189;
 			
-			// aapt resource value: 0x7f0c01d5
-			public const int Widget_MaterialComponents_BottomNavigationView = 2131493333;
+			// aapt resource value: 0x7f0801d6
+			public const int Widget_MaterialComponents_BottomNavigationView = 2131231190;
 			
-			// aapt resource value: 0x7f0c01d6
-			public const int Widget_MaterialComponents_BottomNavigationView_Colored = 2131493334;
+			// aapt resource value: 0x7f0801d7
+			public const int Widget_MaterialComponents_BottomNavigationView_Colored = 2131231191;
 			
-			// aapt resource value: 0x7f0c01d7
-			public const int Widget_MaterialComponents_BottomSheet_Modal = 2131493335;
+			// aapt resource value: 0x7f0801d8
+			public const int Widget_MaterialComponents_BottomSheet_Modal = 2131231192;
 			
-			// aapt resource value: 0x7f0c01d8
-			public const int Widget_MaterialComponents_Button = 2131493336;
+			// aapt resource value: 0x7f0801d9
+			public const int Widget_MaterialComponents_Button = 2131231193;
 			
-			// aapt resource value: 0x7f0c01d9
-			public const int Widget_MaterialComponents_Button_Icon = 2131493337;
+			// aapt resource value: 0x7f0801da
+			public const int Widget_MaterialComponents_Button_Icon = 2131231194;
 			
-			// aapt resource value: 0x7f0c01da
-			public const int Widget_MaterialComponents_Button_OutlinedButton = 2131493338;
+			// aapt resource value: 0x7f0801db
+			public const int Widget_MaterialComponents_Button_OutlinedButton = 2131231195;
 			
-			// aapt resource value: 0x7f0c01db
-			public const int Widget_MaterialComponents_Button_OutlinedButton_Icon = 2131493339;
+			// aapt resource value: 0x7f0801dc
+			public const int Widget_MaterialComponents_Button_OutlinedButton_Icon = 2131231196;
 			
-			// aapt resource value: 0x7f0c01dc
-			public const int Widget_MaterialComponents_Button_TextButton = 2131493340;
+			// aapt resource value: 0x7f0801dd
+			public const int Widget_MaterialComponents_Button_TextButton = 2131231197;
 			
-			// aapt resource value: 0x7f0c01dd
-			public const int Widget_MaterialComponents_Button_TextButton_Dialog = 2131493341;
+			// aapt resource value: 0x7f0801de
+			public const int Widget_MaterialComponents_Button_TextButton_Dialog = 2131231198;
 			
-			// aapt resource value: 0x7f0c01de
-			public const int Widget_MaterialComponents_Button_TextButton_Dialog_Icon = 2131493342;
+			// aapt resource value: 0x7f0801df
+			public const int Widget_MaterialComponents_Button_TextButton_Dialog_Icon = 2131231199;
 			
-			// aapt resource value: 0x7f0c01df
-			public const int Widget_MaterialComponents_Button_TextButton_Icon = 2131493343;
+			// aapt resource value: 0x7f0801e0
+			public const int Widget_MaterialComponents_Button_TextButton_Icon = 2131231200;
 			
-			// aapt resource value: 0x7f0c01e0
-			public const int Widget_MaterialComponents_Button_UnelevatedButton = 2131493344;
+			// aapt resource value: 0x7f0801e1
+			public const int Widget_MaterialComponents_Button_UnelevatedButton = 2131231201;
 			
-			// aapt resource value: 0x7f0c01e1
-			public const int Widget_MaterialComponents_Button_UnelevatedButton_Icon = 2131493345;
+			// aapt resource value: 0x7f0801e2
+			public const int Widget_MaterialComponents_Button_UnelevatedButton_Icon = 2131231202;
 			
-			// aapt resource value: 0x7f0c01e2
-			public const int Widget_MaterialComponents_CardView = 2131493346;
+			// aapt resource value: 0x7f0801e3
+			public const int Widget_MaterialComponents_CardView = 2131231203;
 			
-			// aapt resource value: 0x7f0c01e3
-			public const int Widget_MaterialComponents_Chip_Action = 2131493347;
+			// aapt resource value: 0x7f0801e4
+			public const int Widget_MaterialComponents_Chip_Action = 2131231204;
 			
-			// aapt resource value: 0x7f0c01e4
-			public const int Widget_MaterialComponents_Chip_Choice = 2131493348;
+			// aapt resource value: 0x7f0801e5
+			public const int Widget_MaterialComponents_Chip_Choice = 2131231205;
 			
-			// aapt resource value: 0x7f0c01e5
-			public const int Widget_MaterialComponents_Chip_Entry = 2131493349;
+			// aapt resource value: 0x7f0801e6
+			public const int Widget_MaterialComponents_Chip_Entry = 2131231206;
 			
-			// aapt resource value: 0x7f0c01e6
-			public const int Widget_MaterialComponents_Chip_Filter = 2131493350;
+			// aapt resource value: 0x7f0801e7
+			public const int Widget_MaterialComponents_Chip_Filter = 2131231207;
 			
-			// aapt resource value: 0x7f0c01e7
-			public const int Widget_MaterialComponents_ChipGroup = 2131493351;
+			// aapt resource value: 0x7f0801e8
+			public const int Widget_MaterialComponents_ChipGroup = 2131231208;
 			
-			// aapt resource value: 0x7f0c01e8
-			public const int Widget_MaterialComponents_FloatingActionButton = 2131493352;
+			// aapt resource value: 0x7f0801e9
+			public const int Widget_MaterialComponents_FloatingActionButton = 2131231209;
 			
-			// aapt resource value: 0x7f0c01e9
-			public const int Widget_MaterialComponents_NavigationView = 2131493353;
+			// aapt resource value: 0x7f0801ea
+			public const int Widget_MaterialComponents_NavigationView = 2131231210;
 			
-			// aapt resource value: 0x7f0c01ea
-			public const int Widget_MaterialComponents_Snackbar = 2131493354;
+			// aapt resource value: 0x7f0801eb
+			public const int Widget_MaterialComponents_Snackbar = 2131231211;
 			
-			// aapt resource value: 0x7f0c01eb
-			public const int Widget_MaterialComponents_Snackbar_FullWidth = 2131493355;
+			// aapt resource value: 0x7f0801ec
+			public const int Widget_MaterialComponents_Snackbar_FullWidth = 2131231212;
 			
-			// aapt resource value: 0x7f0c01ec
-			public const int Widget_MaterialComponents_TabLayout = 2131493356;
+			// aapt resource value: 0x7f0801ed
+			public const int Widget_MaterialComponents_TabLayout = 2131231213;
 			
-			// aapt resource value: 0x7f0c01ed
-			public const int Widget_MaterialComponents_TabLayout_Colored = 2131493357;
+			// aapt resource value: 0x7f0801ee
+			public const int Widget_MaterialComponents_TabLayout_Colored = 2131231214;
 			
-			// aapt resource value: 0x7f0c01ee
-			public const int Widget_MaterialComponents_TextInputEditText_FilledBox = 2131493358;
+			// aapt resource value: 0x7f0801ef
+			public const int Widget_MaterialComponents_TextInputEditText_FilledBox = 2131231215;
 			
-			// aapt resource value: 0x7f0c01ef
-			public const int Widget_MaterialComponents_TextInputEditText_FilledBox_Dense = 2131493359;
+			// aapt resource value: 0x7f0801f0
+			public const int Widget_MaterialComponents_TextInputEditText_FilledBox_Dense = 2131231216;
 			
-			// aapt resource value: 0x7f0c01f0
-			public const int Widget_MaterialComponents_TextInputEditText_OutlinedBox = 2131493360;
+			// aapt resource value: 0x7f0801f1
+			public const int Widget_MaterialComponents_TextInputEditText_OutlinedBox = 2131231217;
 			
-			// aapt resource value: 0x7f0c01f1
-			public const int Widget_MaterialComponents_TextInputEditText_OutlinedBox_Dense = 2131493361;
+			// aapt resource value: 0x7f0801f2
+			public const int Widget_MaterialComponents_TextInputEditText_OutlinedBox_Dense = 2131231218;
 			
-			// aapt resource value: 0x7f0c01f2
-			public const int Widget_MaterialComponents_TextInputLayout_FilledBox = 2131493362;
+			// aapt resource value: 0x7f0801f3
+			public const int Widget_MaterialComponents_TextInputLayout_FilledBox = 2131231219;
 			
-			// aapt resource value: 0x7f0c01f3
-			public const int Widget_MaterialComponents_TextInputLayout_FilledBox_Dense = 2131493363;
+			// aapt resource value: 0x7f0801f4
+			public const int Widget_MaterialComponents_TextInputLayout_FilledBox_Dense = 2131231220;
 			
-			// aapt resource value: 0x7f0c01f4
-			public const int Widget_MaterialComponents_TextInputLayout_OutlinedBox = 2131493364;
+			// aapt resource value: 0x7f0801f5
+			public const int Widget_MaterialComponents_TextInputLayout_OutlinedBox = 2131231221;
 			
-			// aapt resource value: 0x7f0c01f5
-			public const int Widget_MaterialComponents_TextInputLayout_OutlinedBox_Dense = 2131493365;
+			// aapt resource value: 0x7f0801f6
+			public const int Widget_MaterialComponents_TextInputLayout_OutlinedBox_Dense = 2131231222;
 			
-			// aapt resource value: 0x7f0c01f6
-			public const int Widget_MaterialComponents_Toolbar = 2131493366;
+			// aapt resource value: 0x7f0801f7
+			public const int Widget_MaterialComponents_Toolbar = 2131231223;
 			
-			// aapt resource value: 0x7f0c0009
-			public const int Widget_MediaRouter_Light_MediaRouteButton = 2131492873;
+			// aapt resource value: 0x7f08000a
+			public const int Widget_MediaRouter_Light_MediaRouteButton = 2131230730;
 			
-			// aapt resource value: 0x7f0c000a
-			public const int Widget_MediaRouter_MediaRouteButton = 2131492874;
+			// aapt resource value: 0x7f08000b
+			public const int Widget_MediaRouter_MediaRouteButton = 2131230731;
 			
-			// aapt resource value: 0x7f0c01f7
-			public const int Widget_Support_CoordinatorLayout = 2131493367;
+			// aapt resource value: 0x7f0801f8
+			public const int Widget_Support_CoordinatorLayout = 2131231224;
+			
+			// aapt resource value: 0x7f080000
+			public const int collectionViewStyle = 2131230720;
 			
 			static Style()
 			{

--- a/Source/BLE.Client/BLE.Client.iOS/BLE.Client.iOS.csproj
+++ b/Source/BLE.Client/BLE.Client.iOS/BLE.Client.iOS.csproj
@@ -200,7 +200,7 @@
       <Version>3.1.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.1.0.581479</Version>
+      <Version>4.2.0.709249</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/Source/BLE.Client/BLE.Client.macOS/BLE.Client.macOS.csproj
+++ b/Source/BLE.Client/BLE.Client.macOS/BLE.Client.macOS.csproj
@@ -109,7 +109,7 @@
       <Version>3.1.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.1.0.581479</Version>
+      <Version>4.2.0.709249</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Source/BLE.Client/BLE.Client/BLE.Client.csproj
+++ b/Source/BLE.Client/BLE.Client/BLE.Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -14,7 +14,7 @@
     <PackageReference Include="MvvmCross.Forms" Version="6.3.1" />
     <PackageReference Include="Plugin.Permissions" Version="3.0.0.12" />
     <PackageReference Include="Xam.Plugins.Settings" Version="3.1.1" />
-    <PackageReference Include="Xamarin.Forms" Version="4.1.0.581479" />
+    <PackageReference Include="Xamarin.Forms" Version="4.2.0.709249" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/BLE.Client/BLE.Client/ViewModels/CharacteristicDetailViewModel.cs
+++ b/Source/BLE.Client/BLE.Client/ViewModels/CharacteristicDetailViewModel.cs
@@ -87,7 +87,7 @@ namespace BLE.Client.ViewModels
 
                 await Characteristic.ReadAsync();
 
-                RaisePropertyChanged(() => CharacteristicValue);
+                await RaisePropertyChanged(() => CharacteristicValue);
 
                 Messages.Insert(0, $"Read value {CharacteristicValue}");
             }
@@ -126,7 +126,7 @@ namespace BLE.Client.ViewModels
                 await Characteristic.WriteAsync(data);
                 _userDialogs.HideLoading();
 
-                RaisePropertyChanged(() => CharacteristicValue);
+                await RaisePropertyChanged(() => CharacteristicValue);
                 Messages.Insert(0, $"Wrote value {CharacteristicValue}");
             }
             catch (Exception ex)
@@ -167,7 +167,7 @@ namespace BLE.Client.ViewModels
 
                 Messages.Insert(0, $"Start updates");
 
-                RaisePropertyChanged(() => UpdateButtonText);
+                await RaisePropertyChanged(() => UpdateButtonText);
 
             }
             catch (Exception ex)
@@ -187,7 +187,7 @@ namespace BLE.Client.ViewModels
 
                 Messages.Insert(0, $"Stop updates");
 
-                RaisePropertyChanged(() => UpdateButtonText);
+                await RaisePropertyChanged(() => UpdateButtonText);
 
             }
             catch (Exception ex)

--- a/Source/BLE.Client/BLE.Client/ViewModels/DescriptorDetailViewModel.cs
+++ b/Source/BLE.Client/BLE.Client/ViewModels/DescriptorDetailViewModel.cs
@@ -61,7 +61,7 @@ namespace BLE.Client.ViewModels
 
                 await Descriptor.ReadAsync();
 
-                RaisePropertyChanged(() => DescriptorValue);
+                await RaisePropertyChanged(() => DescriptorValue);
 
                 Messages.Insert(0, $"Read value {DescriptorValue}");
             }

--- a/Source/BLE.Client/BLE.Client/ViewModels/DescriptorListViewModel.cs
+++ b/Source/BLE.Client/BLE.Client/ViewModels/DescriptorListViewModel.cs
@@ -41,7 +41,7 @@ namespace BLE.Client.ViewModels
             }
 
             Descriptors = await _characteristic.GetDescriptorsAsync();
-            RaisePropertyChanged(nameof(Descriptors));
+            await RaisePropertyChanged(nameof(Descriptors));
         }
 
         public IDescriptor SelectedDescriptor

--- a/Source/BLE.Client/BLE.Client/ViewModels/ServiceListViewModel.cs
+++ b/Source/BLE.Client/BLE.Client/ViewModels/ServiceListViewModel.cs
@@ -36,7 +36,7 @@ namespace BLE.Client.ViewModels
                 _userDialogs.ShowLoading("Discovering services...");
 
                 Services = await _device.GetServicesAsync();
-                RaisePropertyChanged(() => Services);
+                await RaisePropertyChanged(() => Services);
             }
             catch (Exception ex)
             {

--- a/Source/MvvmCross.Plugins.BLE.macOS/Plugin.cs
+++ b/Source/MvvmCross.Plugins.BLE.macOS/Plugin.cs
@@ -24,8 +24,8 @@ namespace MvvmCross.Plugins.BLE.macOS
         public void Load()
         {
             Trace.Message("Loading bluetooth low energy plugin");
-            Mvx.LazyConstructAndRegisterSingleton<IBluetoothLE>(() => CrossBluetoothLE.Current);
-            Mvx.LazyConstructAndRegisterSingleton<IAdapter>(() => Mvx.Resolve<IBluetoothLE>().Adapter);
+            Mvx.LazyConstructAndRegisterSingleton(() => CrossBluetoothLE.Current);
+            Mvx.LazyConstructAndRegisterSingleton(() => Mvx.Resolve<IBluetoothLE>().Adapter);
         }
     }
 }


### PR DESCRIPTION
Suppressed a few warnings across the solution.
Updated Xamarin.Forms to version 4.2.
Fixed an issue with the error toast being displayed for too long.