### PR TITLE
Plugin.BLE.Android: enable BT 5 advertising extensions (#495)

### DIFF
--- a/Source/Plugin.BLE.Android/Adapter.cs
+++ b/Source/Plugin.BLE.Android/Adapter.cs
@@ -97,6 +97,11 @@ namespace Plugin.BLE.Android
 
             var ssb = new ScanSettings.Builder();
             ssb.SetScanMode(ScanMode.ToNative());
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.O)
+            {
+                // enable Bluetooth 5 Advertisement Extensions on Android 8.0 and above
+                ssb.SetLegacy(false);
+            }
             //ssb.SetCallbackType(ScanCallbackType.AllMatches);
 
             if (_bluetoothAdapter.BluetoothLeScanner != null)

--- a/Source/Plugin.BLE.Android/Plugin.BLE.Android.csproj
+++ b/Source/Plugin.BLE.Android/Plugin.BLE.Android.csproj
@@ -14,7 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
     <AndroidTlsProvider>
     </AndroidTlsProvider>
   </PropertyGroup>


### PR DESCRIPTION
* by default only legacy advertisements (4.2 and below) are detected
* see https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder#setLegacy(boolean)
* the target framework version needs to be increased to 8.0 for this