### PR TITLE
Use NSBluetoothAlwaysUsageDescription in iOS and macOS samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Xamarin and MvvMCross plugin for accessing the bluetooth functionality. The plug
 | ------------- | ----------- | ----------- |
 | Xamarin.Android | 4.3 |  |
 | Xamarin.iOS     | 7.0 |  |
-| Xamarin.Mac     | 10.9 (Maveriks) |  >= v2.1.0 |
+| Xamarin.Mac     | 10.9 (Mavericks) |  >= v2.1.0 |
 | UWP             | 1709 - 10.0.16299 (Fall Creators Update) | TBA |
 
 [Changelog](doc/changelog.md)
@@ -73,6 +73,14 @@ On iOS you must add the following keys to your `Info.plist`
     <!--Description of the Bluetooth request message (required on iOS 13)-->
     <key>NSBluetoothAlwaysUsageDescription</key>
     <string>YOUR CUSTOM MESSAGE</string>
+
+**MacOS**
+
+On MacOS (version 11 and above) you must add the following keys to your `Info.plist`:
+
+<!--Description of the Bluetooth request message-->
+<key>NSBluetoothAlwaysUsageDescription</key>
+<string>YOUR CUSTOM MESSAGE</string>
 
 ## Sample app
 

--- a/Source/BLE.Client/BLE.Client.iOS/Info.plist
+++ b/Source/BLE.Client/BLE.Client.iOS/Info.plist
@@ -36,5 +36,7 @@
 	<string>Assets.xcassets/AppIcon.appiconset</string>
 	<key>XSLaunchImageAssets</key>
 	<string>Assets.xcassets/LaunchImage.launchimage</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Need bluetooth permission.</string>
 </dict>
 </plist>

--- a/Source/BLE.Client/BLE.Client.macOS/Info.plist
+++ b/Source/BLE.Client/BLE.Client.macOS/Info.plist
@@ -28,6 +28,7 @@
 	<string>Main</string>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/AppIcon.appiconset</string>
-	
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Need bluetooth permission.</string>
 </dict>
 </plist>


### PR DESCRIPTION
... and mention in the README that it's required on Mac OS Big Sur.

This fixes #498 and #455.