### PR TITLE
Fix Android autoConnect flag

### DIFF
--- a/Source/Plugin.BLE.Android/Adapter.cs
+++ b/Source/Plugin.BLE.Android/Adapter.cs
@@ -19,7 +19,6 @@ namespace Plugin.BLE.Android
 {
     public class Adapter : AdapterBase
     {
-        private ConnectParameters connectParameters;
         private readonly BluetoothManager _bluetoothManager;
         private readonly BluetoothAdapter _bluetoothAdapter;
         private readonly Api18BleScanCallback _api18ScanCallback;
@@ -139,7 +138,6 @@ namespace Plugin.BLE.Android
         protected override Task ConnectToDeviceNativeAsync(IDevice device, ConnectParameters connectParameters,
             CancellationToken cancellationToken)
         {
-            this.connectParameters = connectParameters;
             ((Device)device).Connect(connectParameters, cancellationToken);
             return Task.CompletedTask;
         }
@@ -157,7 +155,6 @@ namespace Plugin.BLE.Android
 
             var device = new Device(this, nativeDevice, null, 0, new byte[] { });
 
-            this.connectParameters = connectParameters;
             await ConnectToDeviceAsync(device, connectParameters, cancellationToken);
             return device;
         }
@@ -187,14 +184,6 @@ namespace Plugin.BLE.Android
             public int GetHashCode(BluetoothDevice obj)
             {
                 return obj.GetHashCode();
-            }
-        }
-
-        public ConnectParameters GetConnectParameters
-        {
-            get
-            {
-                return connectParameters;
             }
         }
 

--- a/Source/Plugin.BLE.Android/Adapter.cs
+++ b/Source/Plugin.BLE.Android/Adapter.cs
@@ -19,6 +19,7 @@ namespace Plugin.BLE.Android
 {
     public class Adapter : AdapterBase
     {
+        private ConnectParameters connectParameters;
         private readonly BluetoothManager _bluetoothManager;
         private readonly BluetoothAdapter _bluetoothAdapter;
         private readonly Api18BleScanCallback _api18ScanCallback;
@@ -138,6 +139,7 @@ namespace Plugin.BLE.Android
         protected override Task ConnectToDeviceNativeAsync(IDevice device, ConnectParameters connectParameters,
             CancellationToken cancellationToken)
         {
+            this.connectParameters = connectParameters;
             ((Device)device).Connect(connectParameters, cancellationToken);
             return Task.CompletedTask;
         }
@@ -155,6 +157,7 @@ namespace Plugin.BLE.Android
 
             var device = new Device(this, nativeDevice, null, 0, new byte[] { });
 
+            this.connectParameters = connectParameters;
             await ConnectToDeviceAsync(device, connectParameters, cancellationToken);
             return device;
         }
@@ -184,6 +187,14 @@ namespace Plugin.BLE.Android
             public int GetHashCode(BluetoothDevice obj)
             {
                 return obj.GetHashCode();
+            }
+        }
+
+        public ConnectParameters GetConnectParameters
+        {
+            get
+            {
+                return connectParameters;
             }
         }
 

--- a/Source/Plugin.BLE.Android/Device.cs
+++ b/Source/Plugin.BLE.Android/Device.cs
@@ -38,6 +38,11 @@ namespace Plugin.BLE.Android
         /// </summary>
         private CancellationTokenRegistration _connectCancellationTokenRegistration;
 
+        /// <summary>
+        /// the connect paramaters used when connecting to this device
+        /// </summary>
+        private ConnectParameters connectParameters;
+
         public Device(Adapter adapter, BluetoothDevice nativeDevice, BluetoothGatt gatt, int rssi, byte[] advertisementData = null) : base(adapter)
         {
             Update(nativeDevice, gatt);
@@ -88,6 +93,7 @@ namespace Plugin.BLE.Android
         public void Connect(ConnectParameters connectParameters, CancellationToken cancellationToken)
         {
             IsOperationRequested = true;
+            this.connectParameters = connectParameters;
 
             if (connectParameters.ForceBleTransport)
             {
@@ -169,6 +175,14 @@ namespace Plugin.BLE.Android
             // ClossGatt might will get called on signal loss without Disconnect being called we have to make sure we clear the services
             // Clear services & characteristics otherwise we will get gatt operation return FALSE when connecting to the same IDevice instace at a later time
             ClearServices();
+        }
+
+        public ConnectParameters GetConnectParameters
+        {
+            get
+            {
+                return connectParameters;
+            }
         }
 
         protected override DeviceState GetState()

--- a/Source/Plugin.BLE.Android/Device.cs
+++ b/Source/Plugin.BLE.Android/Device.cs
@@ -41,7 +41,7 @@ namespace Plugin.BLE.Android
         /// <summary>
         /// the connect paramaters used when connecting to this device
         /// </summary>
-        private ConnectParameters connectParameters;
+        public ConnectParameters ConnectParameters { get; private set; }
 
         public Device(Adapter adapter, BluetoothDevice nativeDevice, BluetoothGatt gatt, int rssi, byte[] advertisementData = null) : base(adapter)
         {
@@ -93,7 +93,7 @@ namespace Plugin.BLE.Android
         public void Connect(ConnectParameters connectParameters, CancellationToken cancellationToken)
         {
             IsOperationRequested = true;
-            this.connectParameters = connectParameters;
+            ConnectParameters = connectParameters;
 
             if (connectParameters.ForceBleTransport)
             {
@@ -164,7 +164,7 @@ namespace Plugin.BLE.Android
         }
 
         /// <summary>
-        /// CloseGatt is called by the gattCallback in case of user disconnect or a disconnect by signal loss or a connection error. 
+        /// CloseGatt is called by the gattCallback in case of user disconnect or a disconnect by signal loss or a connection error.
         /// Cleares all cached services.
         /// </summary>
         public void CloseGatt()
@@ -175,14 +175,6 @@ namespace Plugin.BLE.Android
             // ClossGatt might will get called on signal loss without Disconnect being called we have to make sure we clear the services
             // Clear services & characteristics otherwise we will get gatt operation return FALSE when connecting to the same IDevice instace at a later time
             ClearServices();
-        }
-
-        public ConnectParameters GetConnectParameters
-        {
-            get
-            {
-                return connectParameters;
-            }
         }
 
         protected override DeviceState GetState()
@@ -230,7 +222,7 @@ namespace Plugin.BLE.Android
             while (index < scanRecord.Length)
             {
                 byte length = scanRecord[index++];
-                //Done once we run out of records 
+                //Done once we run out of records
                 // 1 byte for type and length-1 bytes for data
                 if (length == 0) break;
 

--- a/Source/Plugin.BLE.Android/GattCallback.cs
+++ b/Source/Plugin.BLE.Android/GattCallback.cs
@@ -58,7 +58,7 @@ namespace Plugin.BLE.Android
                 case ProfileState.Disconnected:
 
                     // Close GATT if autoConnect is disabled, else we can accumulate zombie gatts.
-                    if (!_device.GetConnectParameters.AutoConnect)
+                    if (!_device.ConnectParameters.AutoConnect)
                     {
                         CloseGattInstances(gatt);
                     }

--- a/Source/Plugin.BLE.Android/GattCallback.cs
+++ b/Source/Plugin.BLE.Android/GattCallback.cs
@@ -57,8 +57,11 @@ namespace Plugin.BLE.Android
                 // disconnected
                 case ProfileState.Disconnected:
 
-                    // Close GATT regardless, else we can accumulate zombie gatts.
-                    CloseGattInstances(gatt);
+                    // Close GATT if autoConnect is disabled, else we can accumulate zombie gatts.
+                    if (!_adapter.GetConnectParameters.AutoConnect)
+                    {
+                        CloseGattInstances(gatt);
+                    }
 
                     // If status == 19, then connection was closed by the peripheral device (clean disconnect), consider this as a DeviceDisconnected
                     if (_device.IsOperationRequested || (int)status == 19)

--- a/Source/Plugin.BLE.Android/GattCallback.cs
+++ b/Source/Plugin.BLE.Android/GattCallback.cs
@@ -58,7 +58,7 @@ namespace Plugin.BLE.Android
                 case ProfileState.Disconnected:
 
                     // Close GATT if autoConnect is disabled, else we can accumulate zombie gatts.
-                    if (!_adapter.GetConnectParameters.AutoConnect)
+                    if (!_device.GetConnectParameters.AutoConnect)
                     {
                         CloseGattInstances(gatt);
                     }


### PR DESCRIPTION
Resolves #182 

Basically only closes the gatt instance when autoConnect was set to false when connecting to that device