### PR TITLE
Adds GetKnownDevicesByIds-Method to get paired devices without the need of connecting to them

### DIFF
--- a/Source/Plugin.BLE.Abstractions/AdapterBase.cs
+++ b/Source/Plugin.BLE.Abstractions/AdapterBase.cs
@@ -239,5 +239,6 @@ namespace Plugin.BLE.Abstractions
 
         public abstract Task<IDevice> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default, CancellationToken cancellationToken = default);
         public abstract IReadOnlyList<IDevice> GetSystemConnectedOrPairedDevices(Guid[] services = null);
+        public abstract IReadOnlyList<IDevice> GetKnownDevicesByIds(Guid[] ids);
     }
 }

--- a/Source/Plugin.BLE.Abstractions/Contracts/IAdapter.cs
+++ b/Source/Plugin.BLE.Abstractions/Contracts/IAdapter.cs
@@ -126,5 +126,13 @@ namespace Plugin.BLE.Abstractions.Contracts
         /// <param name="services">IMPORTANT: Only considered by iOS due to platform limitations. Filters devices by advertised services. SET THIS VALUE FOR ANY RESULTS</param>
         /// <returns>List of IDevices connected to the OS.  In case of no devices the list is empty.</returns>
         IReadOnlyList<IDevice> GetSystemConnectedOrPairedDevices(Guid[] services = null);
+        
+        /// <summary>
+        /// Returns a list of paired BLE devices for the given UUIDs.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">When ids is null</exception>
+        /// <param name="ids">The list of UUIDs</param>
+        /// <returns>The known device. Empty list if no device known.</returns>
+        IReadOnlyList<IDevice> GetKnownDevicesByIds(Guid[] ids);
     }
 }

--- a/Source/Plugin.BLE.Abstractions/Utils/FakeAdapter.cs
+++ b/Source/Plugin.BLE.Abstractions/Utils/FakeAdapter.cs
@@ -46,5 +46,11 @@ namespace Plugin.BLE.Abstractions.Utils
             TraceUnavailability();
             return new List<IDevice>();
         }
+
+        public override IReadOnlyList<IDevice> GetKnownDevicesByIds(Guid[] ids)
+        {
+            TraceUnavailability();
+            return new List<IDevice>();
+        }
     }
 }

--- a/Source/Plugin.BLE.Android/Adapter.cs
+++ b/Source/Plugin.BLE.Android/Adapter.cs
@@ -174,6 +174,12 @@ namespace Plugin.BLE.Android
             return connectedDevices.Union(bondedDevices, new DeviceComparer()).Select(d => new Device(this, d, null, 0)).Cast<IDevice>().ToList();
         }
 
+        public override IReadOnlyList<IDevice> GetKnownDevicesByIds(Guid[] ids)
+        {
+            var devices = GetSystemConnectedOrPairedDevices();
+            return devices.Where(item => ids.Contains(item.Id)).ToList();
+        }
+
         private class DeviceComparer : IEqualityComparer<BluetoothDevice>
         {
             public bool Equals(BluetoothDevice x, BluetoothDevice y)

--- a/Source/Plugin.BLE.iOS/Adapter.cs
+++ b/Source/Plugin.BLE.iOS/Adapter.cs
@@ -266,6 +266,19 @@ namespace Plugin.BLE.iOS
             return nativeDevices.Select(d => new Device(this, d, _bleCentralManagerDelegate)).Cast<IDevice>().ToList();
         }
 
+        public override IReadOnlyList<IDevice> GetKnownDevicesByIds(Guid[] ids)
+        {
+            if (ids == null)
+            {
+                throw new ArgumentNullException(nameof(ids));
+            }
+
+            var nativeDevices = _centralManager.RetrievePeripheralsWithIdentifiers(
+                ids.Select(guid => new NSUuid(guid.ToString())).ToArray());
+
+            return nativeDevices.Select(d => new Device(this, d, _bleCentralManagerDelegate)).Cast<IDevice>().ToList();
+        }
+
         private async Task WaitForState(CBCentralManagerState state, CancellationToken cancellationToken, bool configureAwait = false)
         {
             Trace.Message("Adapter: Waiting for state: " + state);


### PR DESCRIPTION
Such a method was missing for iOS as `GetSystemConnectedOrPairedDevices` returned only the currently connected devices. Androids `GetSystemConnectedOrPairedDevices` works just fine.

Introduces a new method to introduce no breaking change for `GetSystemConnectedOrPairedDevices` on iOS, if that method would start to return non-connected, paired devices too.