### PR TITLE
Fix github actions

### DIFF
--- a/.build/MvvmCross.Plugin.BLE.nuspec
+++ b/.build/MvvmCross.Plugin.BLE.nuspec
@@ -92,13 +92,10 @@ Should prevent crashes like: #320
     <file src="out\lib\mvx\netstandard2.0\MvvmCross.Plugins.BLE.*" target="lib\netstandard2.0" />
     <!-- droid -->
     <file src="out\lib\mvx\android\MvvmCross.Plugins.BLE.*" target="lib\MonoAndroid" />
-    <file src="out\lib\mvx\android\MvvmCross.Plugins.BLE.Droid.*" target="lib\MonoAndroid" />
     <!-- iOS -->
     <file src="out\lib\mvx\ios\MvvmCross.Plugins.BLE.*" target="lib\Xamarin.iOS10" />
-    <file src="out\lib\mvx\ios\MvvmCross.Plugins.BLE.iOS.*" target="lib\Xamarin.iOS10" />
     <!-- macOS -->
     <file src="out\lib\mvx\macOS\MvvmCross.Plugins.BLE.*" target="lib\Xamarin.Mac20" />
-    <file src="out\lib\mvx\macOS\MvvmCross.Plugins.BLE.macOS.*" target="lib\Xamarin.Mac20" />
     <!-- icon -->
     <file src="../icon_small.png" target="" />
   </files>

--- a/.build/build.cake
+++ b/.build/build.cake
@@ -1,5 +1,5 @@
-#addin nuget:?package=Cake.Git&version=1.0.1
-#addin nuget:?package=Cake.FileHelpers&version=4.0.0
+#addin nuget:?package=Cake.Git&version=2.0.0
+#addin nuget:?package=Cake.FileHelpers&version=5.0.0
 
 using Path = System.IO.Path;
 using System.Xml.Linq;

--- a/.build/build.cake
+++ b/.build/build.cake
@@ -25,7 +25,7 @@ void BuildProject(string pathPrefix, string projectName, string targetSubDir)
     MSBuild(project, settings => settings
             .SetConfiguration("Release")
             .WithTarget("Build")
-            .UseToolVersion(MSBuildToolVersion.VS2019)
+            .UseToolVersion(MSBuildToolVersion.VS2022)
             .SetMSBuildPlatform(MSBuildPlatform.x86)
             .WithProperty("OutDir", outputDir.FullPath));
 }

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,6 +20,8 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 5.0.x
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.1
     - name: Clean
       uses: cake-build/cake-action@v1
       with:

--- a/Source/Plugin.BLE.Android/Plugin.BLE.Android.csproj
+++ b/Source/Plugin.BLE.Android/Plugin.BLE.Android.csproj
@@ -14,7 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidTlsProvider>
     </AndroidTlsProvider>
   </PropertyGroup>


### PR DESCRIPTION
This fixes the github actions build (via cake), and removes some warnings and errors. Most be the problems were caused by the windows-latest environment having switched to [Windows2022](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md), apparently.
It originally failed with `MSBuild: Could not locate executable.`, but the were a couple more issues and warnings. E.g. we got a `XA5207: Could not find android.jar for API level 26`, because the Windows 2022 environment only includes Android SDK v27 and higher.