### PR TITLE
BLE.Client: update to Android12

### DIFF
--- a/Source/BLE.Client/BLE.Client.Droid/BLE.Client.Droid.csproj
+++ b/Source/BLE.Client/BLE.Client.Droid/BLE.Client.Droid.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Setup.cs" />
     <Compile Include="SplashScreen.cs" />
+    <Compile Include="Helpers\PlatformHelpers.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Properties\AndroidManifest.xml" />
@@ -66,6 +67,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Assets\" />
+    <Folder Include="Helpers\" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\values\style.xml" />

--- a/Source/BLE.Client/BLE.Client.Droid/BLE.Client.Droid.csproj
+++ b/Source/BLE.Client/BLE.Client.Droid/BLE.Client.Droid.csproj
@@ -15,7 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>

--- a/Source/BLE.Client/BLE.Client.Droid/Helpers/PlatformHelpers.cs
+++ b/Source/BLE.Client/BLE.Client.Droid/Helpers/PlatformHelpers.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xamarin.Essentials;
+using Xamarin.Forms;
+using BLE.Client.Helpers;
+
+[assembly: Dependency(typeof(BLE.Client.Droid.Helpers.PlatformHelpers))]
+namespace BLE.Client.Droid.Helpers
+{
+    public class PlatformHelpers : IPlatformHelpers
+    {
+        public async Task<PermissionStatus> CheckAndRequestBluetoothPermissions()
+        {
+            PermissionStatus status;
+            if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.S)
+            {
+                status = await Permissions.CheckStatusAsync<BluetoothSPermission>();
+
+                if (status == PermissionStatus.Granted)
+                    return status;
+
+                status = await Permissions.RequestAsync<BluetoothSPermission>();
+            }
+            else
+            {
+                status = await Permissions.CheckStatusAsync<Permissions.LocationWhenInUse>();
+
+                if (status == PermissionStatus.Granted)
+                    return status;
+
+
+                if (Permissions.ShouldShowRationale<Permissions.LocationWhenInUse>())
+                {
+                    await Application.Current.MainPage.DisplayAlert("Permission required", "Location permission is required for bluetooth scanning. We do not store or use your location at all.", "OK");
+                }
+
+                status = await Permissions.RequestAsync<Permissions.LocationWhenInUse>();
+            }
+            return status;
+        }
+    }
+
+    public class BluetoothSPermission : Xamarin.Essentials.Permissions.BasePlatformPermission
+    {
+        public override (string androidPermission, bool isRuntime)[] RequiredPermissions => new List<(string androidPermission, bool isRuntime)>
+        {
+            (Android.Manifest.Permission.BluetoothScan, true),
+            (Android.Manifest.Permission.BluetoothConnect, true)
+        }.ToArray();
+    }
+}

--- a/Source/BLE.Client/BLE.Client.Droid/Properties/AndroidManifest.xml
+++ b/Source/BLE.Client/BLE.Client.Droid/Properties/AndroidManifest.xml
@@ -1,9 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.ble.client" android:installLocation="auto">
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="31" />
 	<application android:label="BLE Explorer" android:icon="@drawable/icon" android:theme="@style/MyTheme"></application>
-	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-	<uses-permission android:name="android.permission.BLUETOOTH" />
-	<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+	<!-- Request legacy Bluetooth + location permissions on older devices. -->
+	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="30" />
+	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
+	<uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+	<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+	<!-- Request Bluetooth permissions on Android 12 and above (location not necessary). -->
+	<uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
+	<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 </manifest>

--- a/Source/BLE.Client/BLE.Client.iOS/BLE.Client.iOS.csproj
+++ b/Source/BLE.Client/BLE.Client.iOS/BLE.Client.iOS.csproj
@@ -100,6 +100,7 @@
     <ITunesArtwork Include="iTunesArtwork" />
     <ITunesArtwork Include="iTunesArtwork@2x" />
     <Compile Include="LinkerPleaseInclude.cs" />
+    <Compile Include="Helpers\PlatformHelpers.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\MvvmCross.Plugins.BLE.iOS\MvvmCross.Plugins.BLE.iOS.csproj">
@@ -196,6 +197,9 @@
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2012</Version>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Helpers\" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/Source/BLE.Client/BLE.Client.iOS/Helpers/PlatformHelpers.cs
+++ b/Source/BLE.Client/BLE.Client.iOS/Helpers/PlatformHelpers.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Xamarin.Essentials;
+using Xamarin.Forms;
+using BLE.Client.Helpers;
+
+[assembly: Dependency(typeof(BLE.Client.iOS.Helpers.PlatformHelpers))]
+namespace BLE.Client.iOS.Helpers
+{
+    public class PlatformHelpers : IPlatformHelpers
+    {
+        public Task<PermissionStatus> CheckAndRequestBluetoothPermissions()
+        {
+            return Task.FromResult(PermissionStatus.Granted);
+        }
+    }
+}

--- a/Source/BLE.Client/BLE.Client.macOS/BLE.Client.macOS.csproj
+++ b/Source/BLE.Client/BLE.Client.macOS/BLE.Client.macOS.csproj
@@ -76,6 +76,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
+    <Folder Include="Helpers\" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />
@@ -89,6 +90,7 @@
     <Compile Include="ViewController.designer.cs">
       <DependentUpon>ViewController.cs</DependentUpon>
     </Compile>
+    <Compile Include="Helpers\PlatformHelpers.cs" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Main.storyboard" />

--- a/Source/BLE.Client/BLE.Client.macOS/Helpers/PlatformHelpers.cs
+++ b/Source/BLE.Client/BLE.Client.macOS/Helpers/PlatformHelpers.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Xamarin.Essentials;
+using Xamarin.Forms;
+using BLE.Client.Helpers;
+
+[assembly: Dependency(typeof(BLE.Client.macOS.Helpers.PlatformHelpers))]
+namespace BLE.Client.macOS.Helpers
+{
+    public class PlatformHelpers : IPlatformHelpers
+    {
+        public Task<PermissionStatus> CheckAndRequestBluetoothPermissions()
+        {
+            return Task.FromResult(PermissionStatus.Granted);
+        }
+    }
+}

--- a/Source/BLE.Client/BLE.Client/BLE.Client.csproj
+++ b/Source/BLE.Client/BLE.Client/BLE.Client.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <Folder Include="Properties\" />
+    <Folder Include="Helpers\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/BLE.Client/BLE.Client/Helpers/IPlatformHelpers.cs
+++ b/Source/BLE.Client/BLE.Client/Helpers/IPlatformHelpers.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+using Xamarin.Essentials;
+namespace BLE.Client.Helpers
+{
+    public interface IPlatformHelpers
+    {
+        Task<PermissionStatus> CheckAndRequestBluetoothPermissions();
+    }
+}

--- a/Source/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
+++ b/Source/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
@@ -266,26 +266,14 @@ namespace BLE.Client.ViewModels
             RaisePropertyChanged(() => IsRefreshing);
         }
 
-        /// <summary>
-        /// todo - Android 12 needs specific bluetooth scanning permissions, and not necessarily location
-        /// </summary>
-        /// <returns></returns>
         private async Task<bool> HasCorrectPermissions()
         {
-            if (Xamarin.Forms.Device.RuntimePlatform == Device.Android)
+            var permissionResult = await DependencyService.Get<Helpers.IPlatformHelpers>().CheckAndRequestBluetoothPermissions();
+            if (permissionResult != PermissionStatus.Granted)
             {
-                var status = await Permissions.CheckStatusAsync<Permissions.LocationWhenInUse>();
-                if (status != PermissionStatus.Granted)
-                {
-                    var permissionResult = await Permissions.RequestAsync<Permissions.LocationWhenInUse>();
-
-                    if (permissionResult != PermissionStatus.Granted)
-                    {
-                        await _userDialogs.AlertAsync("Permission denied. Not scanning.");
-                        AppInfo.ShowSettingsUI();
-                        return false;
-                    }
-                }
+                await _userDialogs.AlertAsync("Permission denied. Not scanning.");
+                AppInfo.ShowSettingsUI();
+                return false;
             }
 
             return true;


### PR DESCRIPTION
This updates the target framework version to 12 for BLE.Client.Droid, uses the new Bluetooth permission scheme and adds the necessary runtime handling for the new Bluetooth permissions (while keeping backward compatibility to older Android versions). I tested it on Android 11 and 12, and verified that the sample app sees BLE advertisements on both versions.

It is proof that the library works well with Android 12 (without any changes necessary) and only proper permission handling is needed in client apps. It also provide a blueprint of how to handle the new permissions.

Furthermore it removes the requirement for the location permission on Android 12, and thereby fixes #568. It also relates to #579.

The runtime permission handling is inspired by @jamesmontemagno's sketch in https://github.com/xabre/xamarin-bluetooth-le/issues/568#issuecomment-1073134554 and that of @rogihee in https://github.com/xamarin/Essentials/issues/1943#issuecomment-1010444197.

Any comments and testing welcome ...