### PR TITLE
GitHub Actions: run tests

### DIFF
--- a/.build/build.cake
+++ b/.build/build.cake
@@ -83,12 +83,6 @@ Task("BuildClients")
   BuildProject("BLE.Client", "BLE.Client.macOS", Path.Combine("clients", "macOS"));
 });
 
-Task("Build")
-    .IsDependentOn("Clean")
-    .IsDependentOn("Restore")
-    .IsDependentOn("BuildLibs")
-    .Does(() => {});
-
 Task("Clean").Does (() =>
 {
     if (DirectoryExists (BuildTargetDir))
@@ -96,6 +90,46 @@ Task("Clean").Does (() =>
 
     CleanDirectories ("../**/bin");
     CleanDirectories ("../**/obj");
+});
+
+Task("Build")
+    .IsDependentOn("Clean")
+    .IsDependentOn("Restore")
+    .IsDependentOn("BuildLibs")
+    .Does(() => {});
+
+Task("BuildTests")
+    .Does(() =>
+{
+    var projects = GetFiles("../Source/Plugin.BLE.Tests/Plugin.BLE.Tests.csproj");
+    foreach(var project in projects)
+    {
+        DotNetBuild(
+            project.FullPath,
+            new DotNetBuildSettings()
+            {
+                Configuration = "Release",
+                NoRestore = true
+            });
+    }
+});
+
+Task("RunTests")
+    .IsDependentOn("BuildTests")
+    .Does(() =>
+{
+    var projects = GetFiles("../Source/Plugin.BLE.Tests/Plugin.BLE.Tests.csproj");
+    foreach(var project in projects)
+    {
+        DotNetTest(
+            project.FullPath,
+            new DotNetTestSettings()
+            {
+                Configuration = "Release",
+                NoBuild = true,
+                Loggers = { "console;verbosity=detailed" }
+            });
+    }
 });
 
 // ./build.ps1 -Target UpdateVersion -newVersion="2.0.1"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -42,6 +42,16 @@ jobs:
       with:
         script-path: .build/build.cake
         target: BuildClients
+    - name: Builds Tests
+      uses: cake-build/cake-action@v1
+      with:
+        script-path: .build/build.cake
+        target: BuildTests
+    - name: Run Tests
+      uses: cake-build/cake-action@v1
+      with:
+        script-path: .build/build.cake
+        target: RunTests
     - name: Generate nuget package (Vanilla)
       run: nuget pack .build/Plugin.BLE.nuspec -Version $(git describe)
     - name: Generate nuget package (MvvmCross)

--- a/Source/Plugin.BLE.Tests/Plugin.BLE.Tests.csproj
+++ b/Source/Plugin.BLE.Tests/Plugin.BLE.Tests.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This extends the GHA config to build & run the unit tests. As a preparation, the test project is updated to .NET 5 and the cake script is extended to support the unit test. GHA runs the corresponding cake targets in the end. Fixes #583.