### PR TITLE
Scan filtering on service data, manufacturer data or device name

### DIFF
--- a/Source/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
+++ b/Source/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
@@ -317,16 +317,16 @@ namespace BLE.Client.ViewModels
             if (!string.IsNullOrWhiteSpace(ManufacturerIds))
             {
                 var manuIds = ManufacturerIds.Split(',');
-                var list = new List<int>();
+                var list = new List<ManufacturerDataFilter>();
                 foreach (var id in manuIds)
                 {
                     if (int.TryParse(id, out var manuId))
                     {
-                        list.Add(manuId);
+                        list.Add(new ManufacturerDataFilter(manuId));
                     }   
                 }
 
-                scanFilterOptions.ManufacturerIds = list.ToArray();
+                scanFilterOptions.ManufacturerDataFilters = list.ToArray();
             }
             if (!string.IsNullOrWhiteSpace(DeviceAddresses))
             {

--- a/Source/Plugin.BLE.Abstractions/AdapterBase.cs
+++ b/Source/Plugin.BLE.Abstractions/AdapterBase.cs
@@ -80,7 +80,7 @@ namespace Plugin.BLE.Abstractions
             }
         }
 
-        public async Task StartScanningForDevicesAsync(Guid[] serviceUuids = null, Func<IDevice, bool> deviceFilter = null, bool allowDuplicatesKey = false,
+        public async Task StartScanningForDevicesAsync(Guid[] serviceUuids, Func<IDevice, bool> deviceFilter = null, bool allowDuplicatesKey = false,
             CancellationToken cancellationToken = default)
         {
             await StartScanningForDevicesAsync(new ScanFilterOptions { ServiceUuids = serviceUuids }, deviceFilter, allowDuplicatesKey, cancellationToken);

--- a/Source/Plugin.BLE.Abstractions/Contracts/IAdapter.cs
+++ b/Source/Plugin.BLE.Abstractions/Contracts/IAdapter.cs
@@ -84,8 +84,9 @@ namespace Plugin.BLE.Abstractions.Contracts
         /// <summary>
         /// Starts scanning for BLE devices that fulfill the <paramref name="deviceFilter"/>.
         /// DeviceDiscovered will only be called, if <paramref name="deviceFilter"/> returns <c>true</c> for the discovered device.
+        /// This overload takes a list of service IDs and is only kept for backwards compatibility. Might be removed in a future version.
         /// </summary>
-        /// <param name="serviceUuids">Requested service Ids. The default is null.</param>
+        /// <param name="serviceUuids">Requested service Ids.</param>
         /// <param name="deviceFilter">Function that filters the devices. The default is a function that returns true.</param>
         /// <param name="allowDuplicatesKey"> iOS only: If true, filtering is disabled and a discovery event is generated each time the central receives an advertising packet from the peripheral. 
         /// Disabling this filtering can have an adverse effect on battery life and should be used only if necessary.
@@ -94,7 +95,7 @@ namespace Plugin.BLE.Abstractions.Contracts
         /// For android, key is ignored.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is None.</param>
         /// <returns>A task that represents the asynchronous read operation. The Task will finish after the scan has ended.</returns>
-        Task StartScanningForDevicesAsync(Guid[] serviceUuids = null, Func<IDevice, bool> deviceFilter = null, bool allowDuplicatesKey = false, CancellationToken cancellationToken = default);
+        Task StartScanningForDevicesAsync(Guid[] serviceUuids, Func<IDevice, bool> deviceFilter = null, bool allowDuplicatesKey = false, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Stops scanning for BLE devices.

--- a/Source/Plugin.BLE.Abstractions/Extensions/AdapterExtension.cs
+++ b/Source/Plugin.BLE.Abstractions/Extensions/AdapterExtension.cs
@@ -9,7 +9,7 @@ using Plugin.BLE.Abstractions.Utils;
 
 namespace Plugin.BLE.Abstractions.Extensions
 {
-    public static class AdapterExtenstion
+    public static class AdapterExtension
     {
         /// <summary>
         /// Starts scanning for BLE devices.

--- a/Source/Plugin.BLE.Abstractions/Extensions/AdapterExtenstion.cs
+++ b/Source/Plugin.BLE.Abstractions/Extensions/AdapterExtenstion.cs
@@ -19,7 +19,7 @@ namespace Plugin.BLE.Abstractions.Extensions
         /// <returns>A task that represents the asynchronous read operation. The Task will finish after the scan has ended.</returns>
         public static Task StartScanningForDevicesAsync(this IAdapter adapter, CancellationToken cancellationToken)
         {
-            return adapter.StartScanningForDevicesAsync(serviceUuids:null,cancellationToken: cancellationToken);
+            return adapter.StartScanningForDevicesAsync(scanFilterOptions: null, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace Plugin.BLE.Abstractions.Extensions
         /// <returns>A task that represents the asynchronous read operation. The Task will finish after the scan has ended.</returns>
         public static Task StartScanningForDevicesAsync(this IAdapter adapter, Func<IDevice, bool> deviceFilter, CancellationToken cancellationToken = default)
         {
-            return adapter.StartScanningForDevicesAsync(serviceUuids:null,deviceFilter: deviceFilter, cancellationToken: cancellationToken);
+            return adapter.StartScanningForDevicesAsync(scanFilterOptions: null, deviceFilter: deviceFilter, cancellationToken: cancellationToken);
         }
 
         public static Task<IDevice> DiscoverDeviceAsync(this IAdapter adapter, Guid deviceId, CancellationToken cancellationToken = default)

--- a/Source/Plugin.BLE.Abstractions/ScanFilterOptions.cs
+++ b/Source/Plugin.BLE.Abstractions/ScanFilterOptions.cs
@@ -5,36 +5,43 @@ namespace Plugin.BLE.Abstractions
 {
     /// <summary>
     /// A scan filter for service data (including UUID and actual data).
+    /// Android only.
     /// </summary>
     public class ServiceDataFilter
     {
         public Guid ServiceDataUuid { get; set; }
         public byte[] ServiceData { get; set; } = null;
+        public byte[] ServiceDataMask { get; set; } = null;
 
-        public ServiceDataFilter(Guid guid, byte[] data = null)
+        public ServiceDataFilter(Guid guid, byte[] data = null, byte[] mask = null)
         {
             ServiceDataUuid = guid;
             ServiceData = data;
+            ServiceDataMask = mask;
         }
-        public ServiceDataFilter(string uuid, byte[] data = null)
+        public ServiceDataFilter(string uuid, byte[] data = null, byte[] mask = null)
         {
             ServiceDataUuid = new Guid(uuid);
             ServiceData = data;
+            ServiceDataMask = mask;
         }
     }
 
     /// <summary>
     /// A scan filter for manufacturer data (including maufacturer ID and actual data).
+    /// Android only.
     /// </summary>
     public class ManufacturerDataFilter
     {
         public int ManufacturerId { get; set; }
         public byte[] ManufacturerData { get; set; } = null;
+        public byte[] ManufacturerDataMask { get; set; } = null;
 
-        public ManufacturerDataFilter(int mid, byte[] data = null)
+        public ManufacturerDataFilter(int mid, byte[] data = null, byte[] mask = null)
         {
             ManufacturerId = mid;
             ManufacturerData = data;
+            ManufacturerDataMask = mask;
         }
     }
 

--- a/Source/Plugin.BLE.Abstractions/ScanFilterOptions.cs
+++ b/Source/Plugin.BLE.Abstractions/ScanFilterOptions.cs
@@ -1,10 +1,28 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Plugin.BLE.Abstractions
 {
+    /// <summary>
+    /// A scan filter for service data (including UUID and actual data).
+    /// </summary>
+    public class ServiceDataFilter
+    {
+        public Guid ServiceDataUuid { get; set; }
+        public byte[] ServiceData { get; set; } = null;
+
+        public ServiceDataFilter(Guid guid, byte[] data = null)
+        {
+            ServiceDataUuid = guid;
+            ServiceData = data;
+        }
+        public ServiceDataFilter(string uuid, byte[] data = null)
+        {
+            ServiceDataUuid = new Guid(uuid);
+            ServiceData = data;
+        }
+    }
+
     /// <summary>
     /// Pass one or multiple scan filters to filter the scan. Pay attention to which filters are platform specific.
     /// At least one scan filter is required to enable scanning whilst the screen is off in Android.
@@ -14,8 +32,12 @@ namespace Plugin.BLE.Abstractions
         /// <summary>
         /// Android and iOS. Filter the scan by advertised service ids(s)
         /// </summary>
-        //todo add service data filtering as well as UUID
         public Guid[] ServiceUuids { get; set; } = null;
+
+        /// <summary>
+        /// Android only. Filter the scan by service data.
+        /// </summary>
+        public ServiceDataFilter[] ServiceDataFilters { get; set; } = null;
 
         /// <summary>
         /// Android only. Filter the scan by device address(es)
@@ -30,8 +52,9 @@ namespace Plugin.BLE.Abstractions
 
         //todo string [] DeviceNames {get; set;} = null
 
-        public bool HasFilter => HasServiceIds || HasDeviceAddresses || HasManufacturerIds;
+        public bool HasFilter => HasServiceIds || HasServiceData || HasDeviceAddresses || HasManufacturerIds;
         public bool HasServiceIds => ServiceUuids?.Any() == true;
+        public bool HasServiceData => ServiceDataFilters?.Any() == true;
         public bool HasDeviceAddresses => DeviceAddresses?.Any() == true;
         public bool HasManufacturerIds => ManufacturerIds?.Any() == true;
     }

--- a/Source/Plugin.BLE.Abstractions/ScanFilterOptions.cs
+++ b/Source/Plugin.BLE.Abstractions/ScanFilterOptions.cs
@@ -71,12 +71,17 @@ namespace Plugin.BLE.Abstractions
         /// </summary>
         public ManufacturerDataFilter[] ManufacturerDataFilters { get; set; } = null;
 
-        //todo string [] DeviceNames {get; set;} = null
+        /// <summary>
+        /// Android only. Filter the scan by device name(s).
+        /// </summary>
+        public string[] DeviceNames { get; set; } = null;
 
-        public bool HasFilter => HasServiceIds || HasServiceData || HasDeviceAddresses || HasManufacturerIds;
+        public bool HasFilter => HasServiceIds || HasServiceData || HasDeviceAddresses || HasManufacturerIds || HasDeviceNames;
+
         public bool HasServiceIds => ServiceUuids?.Any() == true;
         public bool HasServiceData => ServiceDataFilters?.Any() == true;
         public bool HasDeviceAddresses => DeviceAddresses?.Any() == true;
         public bool HasManufacturerIds => ManufacturerDataFilters?.Any() == true;
+        public bool HasDeviceNames => DeviceNames?.Any() == true;
     }
 }

--- a/Source/Plugin.BLE.Abstractions/ScanFilterOptions.cs
+++ b/Source/Plugin.BLE.Abstractions/ScanFilterOptions.cs
@@ -49,7 +49,7 @@ namespace Plugin.BLE.Abstractions
     public class ScanFilterOptions
     {
         /// <summary>
-        /// Android and iOS. Filter the scan by advertised service ids(s)
+        /// Android/iOS/MacOS. Filter the scan by advertised service ID(s).
         /// </summary>
         public Guid[] ServiceUuids { get; set; } = null;
 

--- a/Source/Plugin.BLE.Abstractions/ScanFilterOptions.cs
+++ b/Source/Plugin.BLE.Abstractions/ScanFilterOptions.cs
@@ -16,14 +16,11 @@ namespace Plugin.BLE.Abstractions
         public ServiceDataFilter(Guid guid, byte[] data = null, byte[] mask = null)
         {
             ServiceDataUuid = guid;
-            ServiceData = data;
+            ServiceData = data ?? Array.Empty<byte>();
             ServiceDataMask = mask;
         }
-        public ServiceDataFilter(string uuid, byte[] data = null, byte[] mask = null)
+        public ServiceDataFilter(string uuid, byte[] data = null, byte[] mask = null) : this(new Guid(uuid), data, mask)
         {
-            ServiceDataUuid = new Guid(uuid);
-            ServiceData = data;
-            ServiceDataMask = mask;
         }
     }
 
@@ -40,7 +37,7 @@ namespace Plugin.BLE.Abstractions
         public ManufacturerDataFilter(int mid, byte[] data = null, byte[] mask = null)
         {
             ManufacturerId = mid;
-            ManufacturerData = data;
+            ManufacturerData = data ?? Array.Empty<byte>();
             ManufacturerDataMask = mask;
         }
     }

--- a/Source/Plugin.BLE.Abstractions/ScanFilterOptions.cs
+++ b/Source/Plugin.BLE.Abstractions/ScanFilterOptions.cs
@@ -24,6 +24,21 @@ namespace Plugin.BLE.Abstractions
     }
 
     /// <summary>
+    /// A scan filter for manufacturer data (including maufacturer ID and actual data).
+    /// </summary>
+    public class ManufacturerDataFilter
+    {
+        public int ManufacturerId { get; set; }
+        public byte[] ManufacturerData { get; set; } = null;
+
+        public ManufacturerDataFilter(int mid, byte[] data = null)
+        {
+            ManufacturerId = mid;
+            ManufacturerData = data;
+        }
+    }
+
+    /// <summary>
     /// Pass one or multiple scan filters to filter the scan. Pay attention to which filters are platform specific.
     /// At least one scan filter is required to enable scanning whilst the screen is off in Android.
     /// </summary>
@@ -45,10 +60,9 @@ namespace Plugin.BLE.Abstractions
         public string[] DeviceAddresses { get; set; } = null;
 
         /// <summary>
-        /// Android only. Filter the scan by manufacturer ids.
+        /// Android only. Filter the scan by manufacturer data.
         /// </summary>
-        //todo - allow filtering by manufacturer byte[] data
-        public int[] ManufacturerIds { get; set; } = null;
+        public ManufacturerDataFilter[] ManufacturerDataFilters { get; set; } = null;
 
         //todo string [] DeviceNames {get; set;} = null
 
@@ -56,6 +70,6 @@ namespace Plugin.BLE.Abstractions
         public bool HasServiceIds => ServiceUuids?.Any() == true;
         public bool HasServiceData => ServiceDataFilters?.Any() == true;
         public bool HasDeviceAddresses => DeviceAddresses?.Any() == true;
-        public bool HasManufacturerIds => ManufacturerIds?.Any() == true;
+        public bool HasManufacturerIds => ManufacturerDataFilters?.Any() == true;
     }
 }

--- a/Source/Plugin.BLE.Android/Adapter.cs
+++ b/Source/Plugin.BLE.Android/Adapter.cs
@@ -105,10 +105,10 @@ namespace Plugin.BLE.Android
                 }
                 if (scanFilterOptions.HasManufacturerIds)
                 {
-                    foreach (var manufacturerId in scanFilterOptions.ManufacturerIds)
+                    foreach (var manufacturerDataFilter in scanFilterOptions.ManufacturerDataFilters)
                     {
                         var sfb = new ScanFilter.Builder();
-                        sfb.SetManufacturerData(manufacturerId,Array.Empty<byte>()); // future enhancement, add manufacturer byte data to filter
+                        sfb.SetManufacturerData(manufacturerDataFilter.ManufacturerId, manufacturerDataFilter.ManufacturerData);
                         scanFilters.Add(sfb.Build());
                     }
                 }
@@ -156,7 +156,7 @@ namespace Plugin.BLE.Android
                     }
                     if (scanFilterOptions.HasManufacturerIds)
                     {
-                        Trace.Message($"Manufacturer Id Scan Filters: {string.Join(", ", scanFilterOptions.ManufacturerIds)}");
+                        Trace.Message($"Manufacturer Id Scan Filters: {string.Join(", ", scanFilterOptions.ManufacturerDataFilters.ToString())}");
                     }
                     if (scanFilterOptions.HasDeviceAddresses)
                     {

--- a/Source/Plugin.BLE.Android/Adapter.cs
+++ b/Source/Plugin.BLE.Android/Adapter.cs
@@ -99,7 +99,10 @@ namespace Plugin.BLE.Android
                     foreach (var serviceDataFilter in scanFilterOptions.ServiceDataFilters)
                     {
                         var sfb = new ScanFilter.Builder();
-                        sfb.SetServiceData(ParcelUuid.FromString(serviceDataFilter.ServiceDataUuid.ToString()), serviceDataFilter.ServiceData, serviceDataFilter.ServiceDataMask);
+                        if (serviceDataFilter.ServiceDataMask == null)
+                            sfb.SetServiceData(ParcelUuid.FromString(serviceDataFilter.ServiceDataUuid.ToString()), serviceDataFilter.ServiceData);
+                        else
+                            sfb.SetServiceData(ParcelUuid.FromString(serviceDataFilter.ServiceDataUuid.ToString()), serviceDataFilter.ServiceData, serviceDataFilter.ServiceDataMask);
                         scanFilters.Add(sfb.Build());
                     }
                 }
@@ -108,7 +111,10 @@ namespace Plugin.BLE.Android
                     foreach (var manufacturerDataFilter in scanFilterOptions.ManufacturerDataFilters)
                     {
                         var sfb = new ScanFilter.Builder();
-                        sfb.SetManufacturerData(manufacturerDataFilter.ManufacturerId, manufacturerDataFilter.ManufacturerData, manufacturerDataFilter.ManufacturerDataMask);
+                        if (manufacturerDataFilter.ManufacturerDataMask != null)
+                            sfb.SetManufacturerData(manufacturerDataFilter.ManufacturerId, manufacturerDataFilter.ManufacturerData);
+                        else
+                            sfb.SetManufacturerData(manufacturerDataFilter.ManufacturerId, manufacturerDataFilter.ManufacturerData, manufacturerDataFilter.ManufacturerDataMask);
                         scanFilters.Add(sfb.Build());
                     }
                 }

--- a/Source/Plugin.BLE.Android/Adapter.cs
+++ b/Source/Plugin.BLE.Android/Adapter.cs
@@ -99,7 +99,7 @@ namespace Plugin.BLE.Android
                     foreach (var serviceDataFilter in scanFilterOptions.ServiceDataFilters)
                     {
                         var sfb = new ScanFilter.Builder();
-                        sfb.SetServiceData(ParcelUuid.FromString(serviceDataFilter.ServiceDataUuid.ToString()), serviceDataFilter.ServiceData);
+                        sfb.SetServiceData(ParcelUuid.FromString(serviceDataFilter.ServiceDataUuid.ToString()), serviceDataFilter.ServiceData, serviceDataFilter.ServiceDataMask);
                         scanFilters.Add(sfb.Build());
                     }
                 }
@@ -108,7 +108,7 @@ namespace Plugin.BLE.Android
                     foreach (var manufacturerDataFilter in scanFilterOptions.ManufacturerDataFilters)
                     {
                         var sfb = new ScanFilter.Builder();
-                        sfb.SetManufacturerData(manufacturerDataFilter.ManufacturerId, manufacturerDataFilter.ManufacturerData);
+                        sfb.SetManufacturerData(manufacturerDataFilter.ManufacturerId, manufacturerDataFilter.ManufacturerData, manufacturerDataFilter.ManufacturerDataMask);
                         scanFilters.Add(sfb.Build());
                     }
                 }

--- a/Source/Plugin.BLE.Android/Adapter.cs
+++ b/Source/Plugin.BLE.Android/Adapter.cs
@@ -94,6 +94,15 @@ namespace Plugin.BLE.Android
                         scanFilters.Add(sfb.Build());
                     }
                 }
+                if (scanFilterOptions.HasServiceData)
+                {
+                    foreach (var serviceDataFilter in scanFilterOptions.ServiceDataFilters)
+                    {
+                        var sfb = new ScanFilter.Builder();
+                        sfb.SetServiceData(ParcelUuid.FromString(serviceDataFilter.ServiceDataUuid.ToString()), serviceDataFilter.ServiceData);
+                        scanFilters.Add(sfb.Build());
+                    }
+                }
                 if (scanFilterOptions.HasManufacturerIds)
                 {
                     foreach (var manufacturerId in scanFilterOptions.ManufacturerIds)
@@ -140,6 +149,10 @@ namespace Plugin.BLE.Android
                     if (scanFilterOptions.HasServiceIds)
                     {
                         Trace.Message($"Service UUID Scan Filters: {string.Join(", ", scanFilterOptions.ServiceUuids)}");
+                    }
+                    if (scanFilterOptions.HasServiceData)
+                    {
+                        Trace.Message($"Service Data Scan Filters: {string.Join(", ", scanFilterOptions.ServiceDataFilters.ToString())}");
                     }
                     if (scanFilterOptions.HasManufacturerIds)
                     {

--- a/Source/Plugin.BLE.Android/Adapter.cs
+++ b/Source/Plugin.BLE.Android/Adapter.cs
@@ -129,6 +129,15 @@ namespace Plugin.BLE.Android
                
                     }
                 }
+                if (scanFilterOptions.HasDeviceNames)
+                {
+                    foreach (var deviceName in scanFilterOptions.DeviceNames)
+                    {
+                        var sfb = new ScanFilter.Builder();
+                        sfb.SetDeviceName(deviceName);
+                        scanFilters.Add(sfb.Build());
+                    }
+                }
                
             }
 
@@ -162,7 +171,10 @@ namespace Plugin.BLE.Android
                     {
                         Trace.Message($"Device Address Scan Filters: {string.Join(", ", scanFilterOptions.DeviceAddresses)}");
                     }
-                    
+                    if (scanFilterOptions.HasDeviceNames)
+                    {
+                        Trace.Message($"Device Name Scan Filters: {string.Join(", ", scanFilterOptions.DeviceNames)}");
+                    }
                 }
                 _bluetoothAdapter.BluetoothLeScanner.StartScan(scanFilters, ssb.Build(), _api21ScanCallback);
             }


### PR DESCRIPTION
This is a follow-up to @AdamDiament's #578. It further extends the scan-filtering capabilities (on Android) with the option to filter on service data.
It also fixes a problem with the overloading of `IAdapter.StartScanningForDevicesAsync` that was introduced in #578 as well as a long-standing typo in a class name in one of the extension classes.