### PR TITLE
Added null-check to StartScanningForDevicesNativeAsync

### DIFF
--- a/Source/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
+++ b/Source/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
@@ -51,7 +51,7 @@ namespace BLE.Client.ViewModels
         public MvxCommand<DeviceListItemViewModel> ConnectDisposeCommand => new MvxCommand<DeviceListItemViewModel>(ConnectAndDisposeDevice);
 
         public ObservableCollection<DeviceListItemViewModel> Devices { get; set; } = new ObservableCollection<DeviceListItemViewModel>();
-        public bool IsRefreshing => (Adapter != null) ? Adapter.IsScanning : false;
+        public bool IsRefreshing => Adapter?.IsScanning ?? false;
         public bool IsStateOn => _bluetoothLe.IsOn;
         public string StateText => GetStateText();
         public DeviceListItemViewModel SelectedDevice

--- a/Source/Plugin.BLE.UWP/Adapter.cs
+++ b/Source/Plugin.BLE.UWP/Adapter.cs
@@ -28,7 +28,7 @@ namespace Plugin.BLE.UWP
 
         protected override Task StartScanningForDevicesNativeAsync(ScanFilterOptions scanFilterOptions, bool allowDuplicatesKey, CancellationToken scanCancellationToken)
         {
-            var serviceUuids = scanFilterOptions.ServiceUuids;
+            var serviceUuids = scanFilterOptions?.ServiceUuids;
             var hasFilter = serviceUuids?.Any() ?? false;
 
             _bleWatcher = new BluetoothLEAdvertisementWatcher { ScanningMode = ScanMode.ToNative() };


### PR DESCRIPTION
In Adapter.cs, if StartScanningForDevicesNativeAsync is called without specifying ScanFilterOptions (via the IAdapter overload which takes no parameters), then the lack of a null-check causes a crash.

In DeviceListViewModel.cs, I had previously submitted a pull request to add a null-check which had been accepted (commit 2317429f8a5e7153c00e090e9a66ccb3f49e4ad0), but it used the old-style syntax for null-guarding. This pull request updates it to the new C# syntax for null-guarding.