### PR TITLE
Added null-checks

### DIFF
--- a/Source/Plugin.BLE.Abstractions/DeviceBase.cs
+++ b/Source/Plugin.BLE.Abstractions/DeviceBase.cs
@@ -68,7 +68,9 @@ namespace Plugin.BLE.Abstractions
 
                 lock (KnownServices)
                 {
-                    KnownServices.AddRange(services);
+                    if (services != null)
+                        KnownServices.AddRange(services);
+
                     return KnownServices.ToArray();
                 }
             }

--- a/Source/Plugin.BLE.UWP/Device.cs
+++ b/Source/Plugin.BLE.UWP/Device.cs
@@ -40,13 +40,16 @@ namespace Plugin.BLE.UWP
 
         protected override async Task<IReadOnlyList<IService>> GetServicesNativeAsync()
         {
-            var result = await NativeDevice.BluetoothLEDevice.GetGattServicesAsync(BleImplementation.CacheModeGetServices);
-            result.ThrowIfError();
+            if (NativeDevice?.BluetoothLEDevice == null)
+                return new List<IService>();
 
-            return result.Services?
+            var result = await NativeDevice.BluetoothLEDevice.GetGattServicesAsync(BleImplementation.CacheModeGetServices);
+            result?.ThrowIfError();
+
+            return result?.Services?
                 .Select(nativeService => new Service(nativeService, this))
                 .Cast<IService>()
-                .ToList();
+                .ToList() ?? new List<IService>();
         }
 
         protected override async Task<IService> GetServiceNativeAsync(Guid id)


### PR DESCRIPTION
Revised null handling that returns an empty list from GetServicesNativeAsync() in order to match the way that the Android code handles errors in GetServicesNativeAsync()