### PR TITLE
Fix for Acr.UserDialogs bait library problem

### DIFF
--- a/Source/BLE.Client/BLE.Client.Droid/BLE.Client.Droid.csproj
+++ b/Source/BLE.Client/BLE.Client.Droid/BLE.Client.Droid.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -67,7 +67,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Assets\" />
-    <Folder Include="Helpers\" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\values\style.xml" />
@@ -114,7 +113,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Acr.UserDialogs">
-      <Version>7.2.0.564</Version>
+      <Version>7.1.0.514</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross">
       <Version>7.1.2</Version>

--- a/Source/BLE.Client/BLE.Client.UWP/BLE.Client.UWP.csproj
+++ b/Source/BLE.Client/BLE.Client.UWP/BLE.Client.UWP.csproj
@@ -168,7 +168,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Acr.UserDialogs">
-      <Version>7.2.0.564</Version>
+      <Version>7.1.0.514</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.13</Version>

--- a/Source/BLE.Client/BLE.Client.UWP/BLE.Client.UWP.csproj
+++ b/Source/BLE.Client/BLE.Client.UWP/BLE.Client.UWP.csproj
@@ -95,6 +95,7 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Helpers\PlatformHelpers.cs" />
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
@@ -197,6 +198,7 @@
       <Name>Plugin.BLE.UWP</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/Source/BLE.Client/BLE.Client.UWP/Helpers/PlatformHelpers.cs
+++ b/Source/BLE.Client/BLE.Client.UWP/Helpers/PlatformHelpers.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Xamarin.Essentials;
+using Xamarin.Forms;
+using BLE.Client.Helpers;
+
+[assembly: Dependency(typeof(BLE.Client.UWP.Helpers.PlatformHelpers))]
+namespace BLE.Client.UWP.Helpers
+{
+    public class PlatformHelpers : IPlatformHelpers
+    {
+        public Task<PermissionStatus> CheckAndRequestBluetoothPermissions()
+        {
+            return Task.FromResult(PermissionStatus.Granted);
+        }
+    }
+}

--- a/Source/BLE.Client/BLE.Client.iOS/BLE.Client.iOS.csproj
+++ b/Source/BLE.Client/BLE.Client.iOS/BLE.Client.iOS.csproj
@@ -186,7 +186,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Acr.UserDialogs">
-      <Version>7.2.0.564</Version>
+      <Version>7.1.0.514</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross">
       <Version>7.1.2</Version>
@@ -198,8 +198,6 @@
       <Version>5.0.0.2401</Version>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Helpers\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/Source/BLE.Client/BLE.Client.macOS/BLE.Client.macOS.csproj
+++ b/Source/BLE.Client/BLE.Client.macOS/BLE.Client.macOS.csproj
@@ -76,7 +76,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
-    <Folder Include="Helpers\" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />
@@ -97,7 +96,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Acr.UserDialogs">
-      <Version>7.2.0.564</Version>
+      <Version>7.1.0.514</Version>
     </PackageReference>
     <PackageReference Include="MvvmCross">
       <Version>7.1.2</Version>

--- a/Source/BLE.Client/BLE.Client/BLE.Client.csproj
+++ b/Source/BLE.Client/BLE.Client/BLE.Client.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Acr.UserDialogs" Version="7.2.0.564" />
+    <PackageReference Include="Acr.UserDialogs" Version="7.1.0.514" />
     <PackageReference Include="MvvmCross" Version="7.1.2" />
     <PackageReference Include="MvvmCross.Forms" Version="7.1.2" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2401" />


### PR DESCRIPTION
UWP support in Acr.UserDialogs broke after version 7.1.0.514. And since the project is now abandoned and there is no way to open an issue, I don't know if we can get this fixed. If I create a brand-new empty UWP project and add a NuGet reference to the latest ACR.UserDialogs, I get the same bait library error. Maybe we could email or message the author, Allan Richie (@aritchie).

As a temporary fix until we can figure out the correct fix, I've rolled back the version of Acr.UserDialogs to 7.1.0.514

Visual Studio automatically removed the <ItemGroup> references to the folder 'Helpers', apparently because since the C# file in that folder was referenced directly in the project, the folder reference is superfluous. In any case, the folder still shows up in all the non-UWP projects (where it is actually used).