### PR TITLE
Dont use same event handler for notifications as for read

### DIFF
--- a/Source/Plugin.BLE.Android/Characteristic.cs
+++ b/Source/Plugin.BLE.Android/Characteristic.cs
@@ -55,8 +55,8 @@ namespace Plugin.BLE.Android
                         complete(args.Characteristic.GetValue());
                     }
                 }),
-                subscribeComplete: handler => _gattCallback.CharacteristicValueUpdated += handler,
-                unsubscribeComplete: handler => _gattCallback.CharacteristicValueUpdated -= handler,
+                subscribeComplete: handler => _gattCallback.CharacteristicValueRead += handler,
+                unsubscribeComplete: handler => _gattCallback.CharacteristicValueRead -= handler,
                 getRejectHandler: reject => ((sender, args) =>
                 {
                     reject(new Exception($"Device '{Service.Device.Id}' disconnected while reading characteristic with {Id}."));

--- a/Source/Plugin.BLE.Android/GattCallback.cs
+++ b/Source/Plugin.BLE.Android/GattCallback.cs
@@ -9,6 +9,7 @@ namespace Plugin.BLE.Android
     public interface IGattCallback
     {
         event EventHandler<ServicesDiscoveredCallbackEventArgs> ServicesDiscovered;
+        event EventHandler<CharacteristicReadCallbackEventArgs> CharacteristicValueRead;
         event EventHandler<CharacteristicReadCallbackEventArgs> CharacteristicValueUpdated;
         event EventHandler<CharacteristicWriteCallbackEventArgs> CharacteristicValueWritten;
         event EventHandler<DescriptorCallbackEventArgs> DescriptorValueWritten;
@@ -23,6 +24,7 @@ namespace Plugin.BLE.Android
         private readonly Adapter _adapter;
         private readonly Device _device;
         public event EventHandler<ServicesDiscoveredCallbackEventArgs> ServicesDiscovered;
+        public event EventHandler<CharacteristicReadCallbackEventArgs> CharacteristicValueRead;
         public event EventHandler<CharacteristicReadCallbackEventArgs> CharacteristicValueUpdated;
         public event EventHandler<CharacteristicWriteCallbackEventArgs> CharacteristicValueWritten;
         public event EventHandler<RssiReadCallbackEventArgs> RemoteRssiRead;
@@ -171,7 +173,7 @@ namespace Plugin.BLE.Android
 
             Trace.Message("OnCharacteristicRead: value {0}; status {1}", characteristic.GetValue().ToHexString(), status);
 
-            CharacteristicValueUpdated?.Invoke(this, new CharacteristicReadCallbackEventArgs(characteristic));
+            CharacteristicValueRead?.Invoke(this, new CharacteristicReadCallbackEventArgs(characteristic));
         }
 
         public override void OnCharacteristicChanged(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic)


### PR DESCRIPTION
In our application the value received by an update/notification is not the same as the value read.

So in some cases while we´re doing a read we receive an update and both returns the notification value.

We previously used cordova-plugin-ble-central and they seems to handle reads and notifications differently.